### PR TITLE
FIX: Change profile name

### DIFF
--- a/ui/pyrazer.py
+++ b/ui/pyrazer.py
@@ -576,7 +576,7 @@ class Razer(object):
 		"Set a profile name. newName is expected to be unicode."
 		payload = razer_int_to_be32(profileId)
 		rawstr = unicode(newName)
-		rawstr = str(newName.decode("UTF-16-BE"))[2:]
+		rawstr = rawstr.encode('UTF-16-BE', 'replace')
 		rawstr = rawstr[:min(len(rawstr), 64 * 2)]
 		rawstr += '\0' * (64 * 2 - len(rawstr))
 		payload += rawstr

--- a/ui/qrazercfg
+++ b/ui/qrazercfg
@@ -20,12 +20,6 @@ from PyQt4.QtGui import *
 from pyrazer import *
 
 
-def unicode2QString(uni):
-	return QString.fromUtf8(unicode(uni).decode("UTF-8"))
-
-def QString2unicode(qstr):
-	return unicode(qstr.toUtf8(), "UTF-8").encode("UTF-16")
-
 class OneButtonConfig(QWidget):
 	def __init__(self, id, name, supportedFunctions, buttonConfWidget):
 		QWidget.__init__(self, buttonConfWidget)
@@ -348,10 +342,10 @@ class MouseProfileWidget(QWidget):
 		(newName, ok) = QInputDialog.getText(self, self.tr("New profile name"),
 						     self.tr("New profile name:"),
 						     QLineEdit.Normal,
-						     unicode2QString(name))
+						     name)
 		if not ok:
 			return
-		newName = QString2unicode(newName)
+		newName = (newName)
 		razer.setProfileName(self.mouseWidget.mouse, self.profileId, newName)
 		self.mouseWidget.reloadProfiles()
 


### PR DESCRIPTION
Fixes #7 issue. But changed profile names is lost when razerd daemon is restarted/stopped, eg. when computer restarted.

Review changes. I try to look the code how to implement saving edited profile names.
