### PR TITLE
fixing "filter object is not subscriptable" errors

### DIFF
--- a/ui/razercfg
+++ b/ui/razercfg
@@ -199,7 +199,7 @@ class OpSetLedColor(Operation):
 			else:
 				profile -= 1
 			leds = getRazer().getLeds(idstr, profile)
-			led = filter(lambda l: l.name == ledName, leds)[0]
+			led = next(filter(lambda l: l.name == ledName, leds))
 			led.color = newColor
 			error = getRazer().setLed(idstr, led)
 			if error:
@@ -226,7 +226,7 @@ class OpSetRes(Operation):
 			pm = [m for m in mappings if m.profileMask == 0 or\
 					      m.profileMask & (1 << profile)]
 			try:
-				mapping = filter(lambda m: mapping in m.res, pm)[0].id
+				mapping = next(filter(lambda m: mapping in m.res, pm)).id
 			except IndexError:
 				raise RazerEx("Invalid resolution %d" % mapping)
 		else:


### PR DESCRIPTION
i was getting errors in ui/razercfg because in python3 filter returns an iter, instead of a list.

i've switched to using next(filter(..)) instead of filter(...)[0] to get the first element from the result.
