### PR TITLE
Add DeathAdder Chroma support

### DIFF
--- a/librazer/CMakeLists.txt
+++ b/librazer/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(razer SHARED
 	    hw_copperhead.c
 	    hw_deathadder.c
 	    hw_deathadder2013.c
+	    hw_deathadder_chroma.c
 	    hw_krait.c
 	    hw_lachesis.c
 	    hw_lachesis5k6.c

--- a/librazer/hw_deathadder_chroma.c
+++ b/librazer/hw_deathadder_chroma.c
@@ -526,7 +526,7 @@ static int deathadder_chroma_change_dpimapping(struct razer_mouse_dpimapping *d,
 {
 	struct deathadder_chroma_driver_data *drv_data;
 
-	if (!(d->dimension_mask | (1 << dim)))
+	if (!(d->dimension_mask & (1 << dim)))
 		return -EINVAL;
 
 	if (res == RAZER_MOUSE_RES_UNKNOWN)

--- a/librazer/hw_deathadder_chroma.c
+++ b/librazer/hw_deathadder_chroma.c
@@ -31,9 +31,6 @@
 #define DEATHADDER_CHROMA_DEVICE_NAME    "DeathAdder Chroma"
 #define DEATHADDER_CHROMA_SCROLL_NAME    "Scroll"
 #define DEATHADDER_CHROMA_LOGO_NAME      "GlowingLogo"
-#define DEATHADDER_CHROMA_STATIC_NAME    "Static"
-#define DEATHADDER_CHROMA_SPECTRUM_NAME  "Spectrum"
-#define DEATHADDER_CHROMA_BREATHING_NAME "Breathing"
 
 enum deathadder_chroma_led_id
 {
@@ -88,17 +85,17 @@ enum deathadder_chroma_request
 
 enum
 {
-    DEATHADDER_CHROMA_MAX_FREQUENCY           = RAZER_MOUSE_FREQ_1000HZ,
-    DEATHADDER_CHROMA_MAX_RESOLUTION          = RAZER_MOUSE_RES_10000DPI,
-    DEATHADDER_CHROMA_RESOLUTION_STEP         = RAZER_MOUSE_RES_100DPI,
-    DEATHADDER_CHROMA_SUPPORTED_FREQ_NUM      = 3,
-    DEATHADDER_CHROMA_LED_NUM                 = 2,
-    DEATHADDER_CHROMA_AXES_NUM                = 2,
-    DEATHADDER_CHROMA_DPIMAPPINGS_NUM         = 5,
+    DEATHADDER_CHROMA_MAX_FREQUENCY          = RAZER_MOUSE_FREQ_1000HZ,
+    DEATHADDER_CHROMA_MAX_RESOLUTION         = RAZER_MOUSE_RES_10000DPI,
+    DEATHADDER_CHROMA_RESOLUTION_STEP        = RAZER_MOUSE_RES_100DPI,
+    DEATHADDER_CHROMA_SUPPORTED_FREQ_NUM     = 3,
+    DEATHADDER_CHROMA_LED_NUM                = 2,
+    DEATHADDER_CHROMA_AXES_NUM               = 2,
+    DEATHADDER_CHROMA_DPIMAPPINGS_NUM        = 5,
 
-    DEATHADDER_CHROMA_USB_SETUP_PACKET_VALUE  = 0x300,
-    DEATHADDER_CHROMA_SUCCESS_STATUS          = 0x02,
-    DEATHADDER_CHROMA_PACKET_SPACING_MS       = 35,
+    DEATHADDER_CHROMA_USB_SETUP_PACKET_VALUE = 0x300,
+    DEATHADDER_CHROMA_SUCCESS_STATUS         = 0x02,
+    DEATHADDER_CHROMA_PACKET_SPACING_MS      = 35,
 
     /*
      * Experiments suggest that the value in the 'magic' byte of the command
@@ -155,24 +152,24 @@ struct deathadder_chroma_rgb_color
 
 struct deathadder_chroma_led
 {
-    enum deathadder_chroma_led_id id;
-    enum deathadder_chroma_led_mode mode;
-    enum deathadder_chroma_led_state state;
+    enum deathadder_chroma_led_id      id;
+    enum deathadder_chroma_led_mode    mode;
+    enum deathadder_chroma_led_state   state;
     struct deathadder_chroma_rgb_color color;
 };
 
 struct deathadder_chroma_driver_data
 {
-    uint32_t fw_version;
-    char serial[DEATHADDER_CHROMA_REQUEST_SIZE_GET_SERIAL_NO];
-    struct razer_event_spacing packet_spacing;
+    struct razer_event_spacing     packet_spacing;
+    struct razer_mouse_profile     profile;
     struct razer_mouse_dpimapping *current_dpimapping;
-    struct razer_mouse_dpimapping dpimappings[DEATHADDER_CHROMA_DPIMAPPINGS_NUM];
-    struct deathadder_chroma_led scroll_led;
-    struct deathadder_chroma_led logo_led;
-    enum razer_mouse_freq current_freq;
-    struct razer_mouse_profile profile;
-    struct razer_axis axes[DEATHADDER_CHROMA_AXES_NUM];
+    enum razer_mouse_freq          current_freq;
+    struct deathadder_chroma_led   scroll_led;
+    struct deathadder_chroma_led   logo_led;
+    struct razer_mouse_dpimapping  dpimappings[DEATHADDER_CHROMA_DPIMAPPINGS_NUM];
+    struct razer_axis              axes[DEATHADDER_CHROMA_AXES_NUM];
+    uint16_t                       fw_version;
+    char                   serial[DEATHADDER_CHROMA_REQUEST_SIZE_GET_SERIAL_NO];
 };
 
 static uint8_t deathadder_chroma_checksum(struct deathadder_chroma_command *cmd)

--- a/librazer/hw_deathadder_chroma.c
+++ b/librazer/hw_deathadder_chroma.c
@@ -28,27 +28,31 @@
 #include <stdint.h>
 #include <string.h>
 
-#define DEATHADDER_CHROMA_DEVICE_NAME    "DeathAdder Chroma"
-#define DEATHADDER_CHROMA_SCROLL_NAME    "Scroll"
-#define DEATHADDER_CHROMA_LOGO_NAME      "GlowingLogo"
+static enum razer_mouse_freq deathadder_chroma_freqs_list[] = {
+    RAZER_MOUSE_FREQ_125HZ, RAZER_MOUSE_FREQ_500HZ, RAZER_MOUSE_FREQ_1000HZ};
 
-enum deathadder_chroma_led_id
-{
-    DEATHADDER_CHROMA_LED_ID_SCROLL = 0x01,
-    DEATHADDER_CHROMA_LED_ID_LOGO   = 0x04
+static enum razer_mouse_res deathadder_chroma_resolution_stages_list[] = {
+    RAZER_MOUSE_RES_800DPI, RAZER_MOUSE_RES_1800DPI, RAZER_MOUSE_RES_3500DPI,
+    RAZER_MOUSE_RES_5600DPI, RAZER_MOUSE_RES_10000DPI};
+
+#define DEATHADDER_CHROMA_DEVICE_NAME "DeathAdder Chroma"
+#define DEATHADDER_CHROMA_SCROLL_NAME "Scroll"
+#define DEATHADDER_CHROMA_LOGO_NAME "GlowingLogo"
+
+enum deathadder_chroma_led_id {
+	DEATHADDER_CHROMA_LED_ID_SCROLL = 0x01,
+	DEATHADDER_CHROMA_LED_ID_LOGO = 0x04
 };
 
-enum deathadder_chroma_led_mode
-{
-    DEATHADDER_CHROMA_LED_MODE_STATIC    = 0x00,
-    DEATHADDER_CHROMA_LED_MODE_BREATHING = 0x02,
-    DEATHADDER_CHROMA_LED_MODE_SPECTRUM  = 0X04
+enum deathadder_chroma_led_mode {
+	DEATHADDER_CHROMA_LED_MODE_STATIC = 0x00,
+	DEATHADDER_CHROMA_LED_MODE_BREATHING = 0x02,
+	DEATHADDER_CHROMA_LED_MODE_SPECTRUM = 0X04
 };
 
-enum deathadder_chroma_led_state
-{
-    DEATHADDER_CHROMA_LED_STATE_OFF = 0x00,
-    DEATHADDER_CHROMA_LED_STATE_ON  = 0x01
+enum deathadder_chroma_led_state {
+	DEATHADDER_CHROMA_LED_STATE_OFF = 0x00,
+	DEATHADDER_CHROMA_LED_STATE_ON = 0x01
 };
 
 /*
@@ -59,733 +63,796 @@ enum deathadder_chroma_led_state
  * Experiments suggest that the value given in the 'size' byte does not matter.
  * I chose to go with the values used by the Synapse driver.
  */
-enum deathadder_chroma_request_size
-{
-    DEATHADDER_CHROMA_REQUEST_SIZE_INIT           = 0x02,
-    DEATHADDER_CHROMA_REQUEST_SIZE_SET_RESOLUTION = 0x07,
-    DEATHADDER_CHROMA_REQUEST_SIZE_GET_FIRMWARE   = 0x04,
-    DEATHADDER_CHROMA_REQUEST_SIZE_GET_SERIAL_NO  = 0x16,
-    DEATHADDER_CHROMA_REQUEST_SIZE_SET_FREQUENCY  = 0x01,
-    DEATHADDER_CHROMA_REQUEST_SIZE_SET_LED_STATE  = 0x03,
-    DEATHADDER_CHROMA_REQUEST_SIZE_SET_LED_MODE   = 0x03,
-    DEATHADDER_CHROMA_REQUEST_SIZE_SET_LED_COLOR  = 0x05
+enum deathadder_chroma_request_size {
+	DEATHADDER_CHROMA_REQUEST_SIZE_INIT = 0x02,
+	DEATHADDER_CHROMA_REQUEST_SIZE_SET_RESOLUTION = 0x07,
+	DEATHADDER_CHROMA_REQUEST_SIZE_GET_FIRMWARE = 0x04,
+	DEATHADDER_CHROMA_REQUEST_SIZE_GET_SERIAL_NO = 0x16,
+	DEATHADDER_CHROMA_REQUEST_SIZE_SET_FREQUENCY = 0x01,
+	DEATHADDER_CHROMA_REQUEST_SIZE_SET_LED_STATE = 0x03,
+	DEATHADDER_CHROMA_REQUEST_SIZE_SET_LED_MODE = 0x03,
+	DEATHADDER_CHROMA_REQUEST_SIZE_SET_LED_COLOR = 0x05
 };
 
-enum deathadder_chroma_request
-{
-    DEATHADDER_CHROMA_REQUEST_INIT           = 0x0004,
-    DEATHADDER_CHROMA_REQUEST_SET_RESOLUTION = 0x0405,
-    DEATHADDER_CHROMA_REQUEST_GET_FIRMWARE   = 0x0087,
-    DEATHADDER_CHROMA_REQUEST_GET_SERIAL_NO  = 0x0082,
-    DEATHADDER_CHROMA_REQUEST_SET_FREQUENCY  = 0x0005,
-    DEATHADDER_CHROMA_REQUEST_SET_LED_STATE  = 0x0300,
-    DEATHADDER_CHROMA_REQUEST_SET_LED_MODE   = 0x0302,
-    DEATHADDER_CHROMA_REQUEST_SET_LED_COLOR  = 0x0301
+enum deathadder_chroma_request {
+	DEATHADDER_CHROMA_REQUEST_INIT = 0x0004,
+	DEATHADDER_CHROMA_REQUEST_SET_RESOLUTION = 0x0405,
+	DEATHADDER_CHROMA_REQUEST_GET_FIRMWARE = 0x0087,
+	DEATHADDER_CHROMA_REQUEST_GET_SERIAL_NO = 0x0082,
+	DEATHADDER_CHROMA_REQUEST_SET_FREQUENCY = 0x0005,
+	DEATHADDER_CHROMA_REQUEST_SET_LED_STATE = 0x0300,
+	DEATHADDER_CHROMA_REQUEST_SET_LED_MODE = 0x0302,
+	DEATHADDER_CHROMA_REQUEST_SET_LED_COLOR = 0x0301
 };
 
-enum
-{
-    DEATHADDER_CHROMA_MAX_FREQUENCY          = RAZER_MOUSE_FREQ_1000HZ,
-    DEATHADDER_CHROMA_MAX_RESOLUTION         = RAZER_MOUSE_RES_10000DPI,
-    DEATHADDER_CHROMA_RESOLUTION_STEP        = RAZER_MOUSE_RES_100DPI,
-    DEATHADDER_CHROMA_SUPPORTED_FREQ_NUM     = 3,
-    DEATHADDER_CHROMA_LED_NUM                = 2,
-    DEATHADDER_CHROMA_AXES_NUM               = 2,
-    DEATHADDER_CHROMA_DPIMAPPINGS_NUM        = 5,
+enum deathadder_chroma_constants {
+	DEATHADDER_CHROMA_MAX_FREQUENCY = RAZER_MOUSE_FREQ_1000HZ,
+	DEATHADDER_CHROMA_MAX_RESOLUTION = RAZER_MOUSE_RES_10000DPI,
+	DEATHADDER_CHROMA_RESOLUTION_STEP = RAZER_MOUSE_RES_100DPI,
 
-    DEATHADDER_CHROMA_USB_SETUP_PACKET_VALUE = 0x300,
-    DEATHADDER_CHROMA_SUCCESS_STATUS         = 0x02,
-    DEATHADDER_CHROMA_PACKET_SPACING_MS      = 35,
+	DEATHADDER_CHROMA_LED_NUM = 2,
+	DEATHADDER_CHROMA_AXES_NUM = 2,
+	DEATHADDER_CHROMA_SUPPORTED_FREQ_NUM =
+	    ARRAY_SIZE(deathadder_chroma_freqs_list),
+	DEATHADDER_CHROMA_DPIMAPPINGS_NUM =
+	    ARRAY_SIZE(deathadder_chroma_resolution_stages_list),
 
-    /*
-     * Experiments suggest that the value in the 'magic' byte of the command
-     * does not necessarily matter (e.g. the commands work when the 'magic' byte
-     * equals 0x77). I chose to go with the value used by the Synapse driver.
-     */
-    DEATHADDER_CHROMA_MAGIC_BYTE = 0xFF,
+	DEATHADDER_CHROMA_USB_SETUP_PACKET_VALUE = 0x300,
+	DEATHADDER_CHROMA_SUCCESS_STATUS = 0x02,
+	DEATHADDER_CHROMA_PACKET_SPACING_MS = 35,
 
-    /*
-     * These specific arg0 bytes are used by the Synapse driver for their
-     * respective commands. Their value may or may not matter (e.g. matters in
-     * the case of LED commands, doesn't seem to matter for the resolution
-     * command).
-     */
-    DEATHADDER_CHROMA_LED_ARG0        = 0x01,
-    DEATHADDER_CHROMA_INIT_ARG0       = 0x03,
-    DEATHADDER_CHROMA_RESOLUTION_ARG0 = 0x00
+	/*
+	 * Experiments suggest that the value in the 'magic' byte of the command
+	 * does not necessarily matter (e.g. the commands work when the 'magic'
+	 * byte equals 0x77). I chose to go with the value used by the Synapse
+	 * driver.
+	 */
+	DEATHADDER_CHROMA_MAGIC_BYTE = 0xFF,
+
+	/*
+	 * These specific arg0 bytes are used by the Synapse driver for their
+	 * respective commands. Their value may or may not matter (e.g. matters
+	 * in the case of LED commands, doesn't seem to matter for the
+	 * resolution command).
+	 */
+	DEATHADDER_CHROMA_LED_ARG0 = 0x01,
+	DEATHADDER_CHROMA_INIT_ARG0 = 0x03,
+	DEATHADDER_CHROMA_RESOLUTION_ARG0 = 0x00
 };
 
 struct deathadder_chroma_command
 {
-    uint8_t status;
-    uint8_t magic;
-    uint8_t padding0[3];
-    uint8_t size;
-    be16_t  request;
+	uint8_t status;
+	uint8_t magic;
+	uint8_t padding0[3];
+	uint8_t size;
+	be16_t request;
 
-    union {
-        uint8_t bvalue[80];
-        struct {
-            uint8_t padding1;
-            be16_t  value[38];
-            uint8_t padding2;
-        } _packed;
-    } _packed;
+	union
+	{
+		uint8_t bvalue[80];
+		struct
+		{
+			uint8_t padding1;
+			be16_t value[38];
+			uint8_t padding2;
+		} _packed;
+	} _packed;
 
-    uint8_t checksum;
-    uint8_t padding3;
+	uint8_t checksum;
+	uint8_t padding3;
 } _packed;
 
 static_assert(sizeof(struct deathadder_chroma_command) == 90,
-              "The size of deathadder_chroma_command structure "
-              "must equal 90 bytes.");
+	      "The size of deathadder_chroma_command structure "
+	      "must equal 90 bytes.");
 
 #define DEATHADDER_CHROMA_COMMAND_INIT                                         \
-    (struct deathadder_chroma_command) { .magic = DEATHADDER_CHROMA_MAGIC_BYTE }
+	(struct deathadder_chroma_command)                                     \
+	{                                                                      \
+		.magic = DEATHADDER_CHROMA_MAGIC_BYTE                          \
+	}
 
 struct deathadder_chroma_rgb_color
 {
-    uint8_t r;
-    uint8_t g;
-    uint8_t b;
+	uint8_t r;
+	uint8_t g;
+	uint8_t b;
 };
 
 struct deathadder_chroma_led
 {
-    enum deathadder_chroma_led_id      id;
-    enum deathadder_chroma_led_mode    mode;
-    enum deathadder_chroma_led_state   state;
-    struct deathadder_chroma_rgb_color color;
+	enum deathadder_chroma_led_id id;
+	enum deathadder_chroma_led_mode mode;
+	enum deathadder_chroma_led_state state;
+	struct deathadder_chroma_rgb_color color;
 };
 
 struct deathadder_chroma_driver_data
 {
-    struct razer_event_spacing     packet_spacing;
-    struct razer_mouse_profile     profile;
-    struct razer_mouse_dpimapping *current_dpimapping;
-    enum razer_mouse_freq          current_freq;
-    struct deathadder_chroma_led   scroll_led;
-    struct deathadder_chroma_led   logo_led;
-    struct razer_mouse_dpimapping  dpimappings[DEATHADDER_CHROMA_DPIMAPPINGS_NUM];
-    struct razer_axis              axes[DEATHADDER_CHROMA_AXES_NUM];
-    uint16_t                       fw_version;
-    char                   serial[DEATHADDER_CHROMA_REQUEST_SIZE_GET_SERIAL_NO];
+	struct razer_event_spacing packet_spacing;
+	struct razer_mouse_profile profile;
+	struct razer_mouse_dpimapping *current_dpimapping;
+	enum razer_mouse_freq current_freq;
+	struct deathadder_chroma_led scroll_led;
+	struct deathadder_chroma_led logo_led;
+	struct razer_mouse_dpimapping
+	    dpimappings[DEATHADDER_CHROMA_DPIMAPPINGS_NUM];
+	struct razer_axis axes[DEATHADDER_CHROMA_AXES_NUM];
+	uint16_t fw_version;
+	char serial[DEATHADDER_CHROMA_REQUEST_SIZE_GET_SERIAL_NO];
 };
 
 static uint8_t deathadder_chroma_checksum(struct deathadder_chroma_command *cmd)
 {
-    size_t control_size = sizeof(cmd->size) + sizeof(cmd->request);
-    return razer_xor8_checksum((uint8_t*) &cmd->size, control_size + cmd->size);
+	size_t control_size;
+
+	control_size = sizeof(cmd->size) + sizeof(cmd->request);
+	return razer_xor8_checksum((uint8_t *)&cmd->size,
+				   control_size + cmd->size);
 }
 
 static int deathadder_chroma_translate_frequency(enum razer_mouse_freq freq)
 {
-    switch (freq) {
-        case RAZER_MOUSE_FREQ_UNKNOWN:
-            freq = RAZER_MOUSE_FREQ_500HZ;
+	switch (freq) {
+	case RAZER_MOUSE_FREQ_UNKNOWN:
+		freq = RAZER_MOUSE_FREQ_500HZ;
 
-        case RAZER_MOUSE_FREQ_125HZ:
-        case RAZER_MOUSE_FREQ_500HZ:
-        case RAZER_MOUSE_FREQ_1000HZ:
-            return DEATHADDER_CHROMA_MAX_FREQUENCY / freq;
+	case RAZER_MOUSE_FREQ_125HZ:
+	case RAZER_MOUSE_FREQ_500HZ:
+	case RAZER_MOUSE_FREQ_1000HZ:
+		return DEATHADDER_CHROMA_MAX_FREQUENCY / freq;
 
-        default:
-            return -EINVAL;
-    }
+	default:
+		return -EINVAL;
+	}
 }
 
 static int deathadder_chroma_usb_action(
-        struct razer_mouse *m, enum libusb_endpoint_direction direction,
-        enum libusb_standard_request request, uint16_t command,
-        struct deathadder_chroma_command *cmd)
+    struct razer_mouse *m, enum libusb_endpoint_direction direction,
+    enum libusb_standard_request request, uint16_t command,
+    struct deathadder_chroma_command *cmd)
 {
-    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
+	int err;
+	struct deathadder_chroma_driver_data *drv_data;
 
-    razer_event_spacing_enter(&drv_data->packet_spacing);
-    int err = libusb_control_transfer(
-                m->usb_ctx->h,
-                direction | LIBUSB_REQUEST_TYPE_CLASS |
-                LIBUSB_RECIPIENT_INTERFACE,
-                request, command, 0, (unsigned char*) cmd, sizeof(*cmd),
-                RAZER_USB_TIMEOUT);
-    razer_event_spacing_leave(&drv_data->packet_spacing);
+	drv_data = m->drv_data;
 
-    if (err != sizeof(*cmd)) {
-        razer_error("razer-deathadder-chroma: "
-                    "USB %s 0x%01X 0x%02X failed with %d\n",
-                    direction == LIBUSB_ENDPOINT_IN ? "read" : "write",
-                    request, command, err);
-        return err;
-    }
+	razer_event_spacing_enter(&drv_data->packet_spacing);
+	err = libusb_control_transfer(m->usb_ctx->h,
+				      direction | LIBUSB_REQUEST_TYPE_CLASS |
+					  LIBUSB_RECIPIENT_INTERFACE,
+				      request, command, 0, (unsigned char *)cmd,
+				      sizeof(*cmd), RAZER_USB_TIMEOUT);
+	razer_event_spacing_leave(&drv_data->packet_spacing);
 
-    return 0;
+	if (err != sizeof(*cmd)) {
+		razer_error("razer-deathadder-chroma: "
+			    "USB %s 0x%01X 0x%02X failed with %d\n",
+			    direction == LIBUSB_ENDPOINT_IN ? "read" : "write",
+			    request, command, err);
+		return err;
+	}
+
+	return 0;
 }
 
 static int deathadder_chroma_send_command(struct razer_mouse *m,
-                                          struct deathadder_chroma_command *cmd)
+					  struct deathadder_chroma_command *cmd)
 {
-    cmd->checksum = deathadder_chroma_checksum(cmd);
-    int err = deathadder_chroma_usb_action(
-                m, LIBUSB_ENDPOINT_OUT, LIBUSB_REQUEST_SET_CONFIGURATION,
-                DEATHADDER_CHROMA_USB_SETUP_PACKET_VALUE, cmd);
-    if (err)
-        return err;
+	int err;
+	uint8_t checksum;
 
-    err = deathadder_chroma_usb_action(
-                m, LIBUSB_ENDPOINT_IN, LIBUSB_REQUEST_CLEAR_FEATURE,
-                DEATHADDER_CHROMA_USB_SETUP_PACKET_VALUE, cmd);
-    if (err)
-        return err;
+	cmd->checksum = deathadder_chroma_checksum(cmd);
+	err = deathadder_chroma_usb_action(
+	    m, LIBUSB_ENDPOINT_OUT, LIBUSB_REQUEST_SET_CONFIGURATION,
+	    DEATHADDER_CHROMA_USB_SETUP_PACKET_VALUE, cmd);
+	if (err)
+		return err;
 
-    uint8_t checksum = deathadder_chroma_checksum(cmd);
-    if (checksum != cmd->checksum)
-    {
-        razer_error("razer-deathadder-chroma: "
-                    "Command %02X %04X bad response checksum %02X "
-                    "(expected %02X)\n", cmd->size, be16_to_cpu(cmd->request),
-                    checksum, cmd->checksum);
+	err = deathadder_chroma_usb_action(
+	    m, LIBUSB_ENDPOINT_IN, LIBUSB_REQUEST_CLEAR_FEATURE,
+	    DEATHADDER_CHROMA_USB_SETUP_PACKET_VALUE, cmd);
+	if (err)
+		return err;
 
-        return -EBADMSG;
-    }
+	checksum = deathadder_chroma_checksum(cmd);
+	if (checksum != cmd->checksum) {
+		razer_error("razer-deathadder-chroma: "
+			    "Command %02X %04X bad response checksum %02X "
+			    "(expected %02X)\n",
+			    cmd->size, be16_to_cpu(cmd->request), checksum,
+			    cmd->checksum);
 
-    if (cmd->status != DEATHADDER_CHROMA_SUCCESS_STATUS)
-        razer_error("razer-deathadder-chroma: "
-                    "Command %02X %04X failed with %02X\n",
-                    cmd->size, be16_to_cpu(cmd->request), cmd->status);
+		return -EBADMSG;
+	}
 
-    return 0;
+	if (cmd->status != DEATHADDER_CHROMA_SUCCESS_STATUS)
+		razer_error("razer-deathadder-chroma: "
+			    "Command %02X %04X failed with %02X\n",
+			    cmd->size, be16_to_cpu(cmd->request), cmd->status);
+
+	return 0;
 }
 
 static int deathadder_chroma_send_init_command(struct razer_mouse *m)
 {
-    struct deathadder_chroma_command cmd = DEATHADDER_CHROMA_COMMAND_INIT;
-    cmd.size      = DEATHADDER_CHROMA_REQUEST_SIZE_INIT;
-    cmd.request   = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_INIT);
-    cmd.bvalue[0] = DEATHADDER_CHROMA_INIT_ARG0;
-    return deathadder_chroma_send_command(m, &cmd);
+	struct deathadder_chroma_command cmd;
+
+	cmd = DEATHADDER_CHROMA_COMMAND_INIT;
+	cmd.size = DEATHADDER_CHROMA_REQUEST_SIZE_INIT;
+	cmd.request = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_INIT);
+	cmd.bvalue[0] = DEATHADDER_CHROMA_INIT_ARG0;
+	return deathadder_chroma_send_command(m, &cmd);
 }
 
 static int deathadder_chroma_send_set_resolution_command(struct razer_mouse *m)
 {
-    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
-    enum razer_mouse_res res_x = drv_data->current_dpimapping->res[RAZER_DIM_X];
-    enum razer_mouse_res res_y = drv_data->current_dpimapping->res[RAZER_DIM_Y];
+	enum razer_mouse_res res_x, res_y;
+	struct deathadder_chroma_command cmd;
+	struct deathadder_chroma_driver_data *drv_data;
 
-    struct deathadder_chroma_command cmd = DEATHADDER_CHROMA_COMMAND_INIT;
-    cmd.size      = DEATHADDER_CHROMA_REQUEST_SIZE_SET_RESOLUTION;
-    cmd.request   = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_SET_RESOLUTION);
-    cmd.bvalue[0] = DEATHADDER_CHROMA_RESOLUTION_ARG0;
-    cmd.value[0]  = cpu_to_be16(res_x);
-    cmd.value[1]  = cpu_to_be16(res_y);
-    return deathadder_chroma_send_command(m, &cmd);
+	drv_data = m->drv_data;
+	res_x = drv_data->current_dpimapping->res[RAZER_DIM_X];
+	res_y = drv_data->current_dpimapping->res[RAZER_DIM_Y];
+
+	cmd = DEATHADDER_CHROMA_COMMAND_INIT;
+	cmd.size = DEATHADDER_CHROMA_REQUEST_SIZE_SET_RESOLUTION;
+	cmd.request = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_SET_RESOLUTION);
+	cmd.bvalue[0] = DEATHADDER_CHROMA_RESOLUTION_ARG0;
+	cmd.value[0] = cpu_to_be16(res_x);
+	cmd.value[1] = cpu_to_be16(res_y);
+	return deathadder_chroma_send_command(m, &cmd);
 }
 
 static int deathadder_chroma_send_get_firmware_command(struct razer_mouse *m)
 {
-    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
-    struct deathadder_chroma_command cmd = DEATHADDER_CHROMA_COMMAND_INIT;
-    cmd.size    = DEATHADDER_CHROMA_REQUEST_SIZE_GET_FIRMWARE;
-    cmd.request = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_GET_FIRMWARE);
+	int err;
+	uint8_t fw_major;
+	uint16_t fw_minor;
+	struct deathadder_chroma_command cmd;
+	struct deathadder_chroma_driver_data *drv_data;
 
-    int err = deathadder_chroma_send_command(m, &cmd);
-    if (err)
-        return err;
+	drv_data = m->drv_data;
 
-    uint8_t  fw_major    = cmd.bvalue[0];
-    uint16_t fw_minor    = be16_to_cpu(cmd.value[0]);
-    drv_data->fw_version = (fw_major << 8) | fw_minor;
+	cmd = DEATHADDER_CHROMA_COMMAND_INIT;
+	cmd.size = DEATHADDER_CHROMA_REQUEST_SIZE_GET_FIRMWARE;
+	cmd.request = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_GET_FIRMWARE);
 
-    return 0;
+	err = deathadder_chroma_send_command(m, &cmd);
+	if (err)
+		return err;
+
+	fw_major = cmd.bvalue[0];
+	fw_minor = be16_to_cpu(cmd.value[0]);
+	drv_data->fw_version = (fw_major << 8) | fw_minor;
+
+	return 0;
 }
 
 static int deathadder_chroma_send_get_serial_no_command(struct razer_mouse *m)
 {
-    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
-    struct deathadder_chroma_command cmd = DEATHADDER_CHROMA_COMMAND_INIT;
-    cmd.size    = DEATHADDER_CHROMA_REQUEST_SIZE_GET_SERIAL_NO;
-    cmd.request = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_GET_SERIAL_NO);
+	int err;
+	struct deathadder_chroma_command cmd;
+	struct deathadder_chroma_driver_data *drv_data;
 
-    int err = deathadder_chroma_send_command(m, &cmd);
-    if (err)
-        return err;
+	drv_data = m->drv_data;
 
-    strncpy(drv_data->serial, (const char *) cmd.bvalue,
-            DEATHADDER_CHROMA_REQUEST_SIZE_GET_SERIAL_NO);
-    return 0;
+	cmd = DEATHADDER_CHROMA_COMMAND_INIT;
+	cmd.size = DEATHADDER_CHROMA_REQUEST_SIZE_GET_SERIAL_NO;
+	cmd.request = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_GET_SERIAL_NO);
+
+	err = deathadder_chroma_send_command(m, &cmd);
+	if (err)
+		return err;
+
+	strncpy(drv_data->serial, (const char *)cmd.bvalue,
+		DEATHADDER_CHROMA_REQUEST_SIZE_GET_SERIAL_NO);
+	return 0;
 }
 
 static int deathadder_chroma_send_set_frequency_command(struct razer_mouse *m)
 {
-    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
-    struct deathadder_chroma_command cmd = DEATHADDER_CHROMA_COMMAND_INIT;
-    int tfreq = deathadder_chroma_translate_frequency(drv_data->current_freq);
-    if (tfreq < 0)
-        return tfreq;
+	int tfreq;
+	struct deathadder_chroma_command cmd;
+	struct deathadder_chroma_driver_data *drv_data;
 
-    cmd.size      = DEATHADDER_CHROMA_REQUEST_SIZE_SET_FREQUENCY;
-    cmd.request   = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_SET_FREQUENCY);
-    cmd.bvalue[0] = tfreq;
-    return deathadder_chroma_send_command(m, &cmd);
+	drv_data = m->drv_data;
+	cmd = DEATHADDER_CHROMA_COMMAND_INIT;
+
+	tfreq = deathadder_chroma_translate_frequency(drv_data->current_freq);
+	if (tfreq < 0)
+		return tfreq;
+
+	cmd.size = DEATHADDER_CHROMA_REQUEST_SIZE_SET_FREQUENCY;
+	cmd.request = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_SET_FREQUENCY);
+	cmd.bvalue[0] = tfreq;
+	return deathadder_chroma_send_command(m, &cmd);
 }
 
-static struct deathadder_chroma_led *deathadder_chroma_get_led(
-        struct deathadder_chroma_driver_data *d,
-        enum deathadder_chroma_led_id led_id)
+static struct deathadder_chroma_led *
+deathadder_chroma_get_led(struct deathadder_chroma_driver_data *d,
+			  enum deathadder_chroma_led_id led_id)
 {
-    switch (led_id) {
-        case DEATHADDER_CHROMA_LED_ID_LOGO:   return &d->logo_led;
-        case DEATHADDER_CHROMA_LED_ID_SCROLL: return &d->scroll_led;
-        default: return NULL;
-    }
+	switch (led_id) {
+	case DEATHADDER_CHROMA_LED_ID_LOGO:
+		return &d->logo_led;
+	case DEATHADDER_CHROMA_LED_ID_SCROLL:
+		return &d->scroll_led;
+	default:
+		return NULL;
+	}
 }
 
-static int deathadder_chroma_send_set_led_state_command(
-        struct razer_mouse *m, struct deathadder_chroma_led *led)
+static int
+deathadder_chroma_send_set_led_state_command(struct razer_mouse *m,
+					     struct deathadder_chroma_led *led)
 {
-    struct deathadder_chroma_command cmd = DEATHADDER_CHROMA_COMMAND_INIT;
-    cmd.size      = DEATHADDER_CHROMA_REQUEST_SIZE_SET_LED_STATE;
-    cmd.request   = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_SET_LED_STATE);
-    cmd.bvalue[0] = DEATHADDER_CHROMA_LED_ARG0;
-    cmd.bvalue[1] = led->id;
-    cmd.bvalue[2] = led->state;
-    return deathadder_chroma_send_command(m, &cmd);
+	struct deathadder_chroma_command cmd;
+
+	cmd = DEATHADDER_CHROMA_COMMAND_INIT;
+	cmd.size = DEATHADDER_CHROMA_REQUEST_SIZE_SET_LED_STATE;
+	cmd.request = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_SET_LED_STATE);
+	cmd.bvalue[0] = DEATHADDER_CHROMA_LED_ARG0;
+	cmd.bvalue[1] = led->id;
+	cmd.bvalue[2] = led->state;
+	return deathadder_chroma_send_command(m, &cmd);
 }
 
-static int deathadder_chroma_send_set_led_mode_command(
-        struct razer_mouse *m, struct deathadder_chroma_led *led)
+static int
+deathadder_chroma_send_set_led_mode_command(struct razer_mouse *m,
+					    struct deathadder_chroma_led *led)
 {
-    struct deathadder_chroma_command cmd = DEATHADDER_CHROMA_COMMAND_INIT;
-    cmd.size      = DEATHADDER_CHROMA_REQUEST_SIZE_SET_LED_MODE;
-    cmd.request   = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_SET_LED_MODE);
-    cmd.bvalue[0] = DEATHADDER_CHROMA_LED_ARG0;
-    cmd.bvalue[1] = led->id;
-    cmd.bvalue[2] = led->mode;
-    return deathadder_chroma_send_command(m, &cmd);
+	struct deathadder_chroma_command cmd;
+
+	cmd = DEATHADDER_CHROMA_COMMAND_INIT;
+	cmd.size = DEATHADDER_CHROMA_REQUEST_SIZE_SET_LED_MODE;
+	cmd.request = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_SET_LED_MODE);
+	cmd.bvalue[0] = DEATHADDER_CHROMA_LED_ARG0;
+	cmd.bvalue[1] = led->id;
+	cmd.bvalue[2] = led->mode;
+	return deathadder_chroma_send_command(m, &cmd);
 }
 
-static int deathadder_chroma_send_set_led_color_command(
-        struct razer_mouse *m, struct deathadder_chroma_led *led)
+static int
+deathadder_chroma_send_set_led_color_command(struct razer_mouse *m,
+					     struct deathadder_chroma_led *led)
 {
-    struct deathadder_chroma_command cmd = DEATHADDER_CHROMA_COMMAND_INIT;
-    cmd.size      = DEATHADDER_CHROMA_REQUEST_SIZE_SET_LED_COLOR;
-    cmd.request   = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_SET_LED_COLOR);
-    cmd.bvalue[0] = DEATHADDER_CHROMA_LED_ARG0;
-    cmd.bvalue[1] = led->id;
-    cmd.bvalue[2] = led->color.r;
-    cmd.bvalue[3] = led->color.g;
-    cmd.bvalue[4] = led->color.b;
-    return deathadder_chroma_send_command(m, &cmd);
+	struct deathadder_chroma_command cmd;
+
+	cmd = DEATHADDER_CHROMA_COMMAND_INIT;
+	cmd.size = DEATHADDER_CHROMA_REQUEST_SIZE_SET_LED_COLOR;
+	cmd.request = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_SET_LED_COLOR);
+	cmd.bvalue[0] = DEATHADDER_CHROMA_LED_ARG0;
+	cmd.bvalue[1] = led->id;
+	cmd.bvalue[2] = led->color.r;
+	cmd.bvalue[3] = led->color.g;
+	cmd.bvalue[4] = led->color.b;
+	return deathadder_chroma_send_command(m, &cmd);
 }
 
 static int deathadder_chroma_get_fw_version(struct razer_mouse *m)
 {
-    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
-    return drv_data->fw_version;
+	struct deathadder_chroma_driver_data *drv_data;
+
+	drv_data = m->drv_data;
+	return drv_data->fw_version;
 }
 
-static struct razer_mouse_profile *deathadder_chroma_get_profiles(
-        struct razer_mouse *m)
+static struct razer_mouse_profile *
+deathadder_chroma_get_profiles(struct razer_mouse *m)
 {
-    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
-    return &drv_data->profile;
+	struct deathadder_chroma_driver_data *drv_data;
+
+	drv_data = m->drv_data;
+	return &drv_data->profile;
 }
 
-static int deathadder_chroma_supported_axes(
-        struct razer_mouse *m, struct razer_axis **res_ptr)
+static int deathadder_chroma_supported_axes(struct razer_mouse *m,
+					    struct razer_axis **res_ptr)
 {
-    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
-    *res_ptr = drv_data->axes;
-    return ARRAY_SIZE(drv_data->axes);
+	struct deathadder_chroma_driver_data *drv_data;
+
+	drv_data = m->drv_data;
+	*res_ptr = drv_data->axes;
+	return ARRAY_SIZE(drv_data->axes);
 }
 
-static int deathadder_chroma_supported_dpimappings(
-        struct razer_mouse *m, struct razer_mouse_dpimapping **res_ptr)
+static int
+deathadder_chroma_supported_dpimappings(struct razer_mouse *m,
+					struct razer_mouse_dpimapping **res_ptr)
 {
-    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
-    *res_ptr = drv_data->dpimappings;
-    return ARRAY_SIZE(drv_data->dpimappings);
+	struct deathadder_chroma_driver_data *drv_data;
+
+	drv_data = m->drv_data;
+	*res_ptr = drv_data->dpimappings;
+	return ARRAY_SIZE(drv_data->dpimappings);
 }
 
-static int deathadder_chroma_supported_resolutions(
-        struct razer_mouse *m, enum razer_mouse_res **res_ptr)
+static int
+deathadder_chroma_supported_resolutions(struct razer_mouse *m,
+					enum razer_mouse_res **res_ptr)
 {
-    size_t step_number = DEATHADDER_CHROMA_MAX_RESOLUTION /
-            DEATHADDER_CHROMA_RESOLUTION_STEP;
+	size_t i;
+	size_t step_number;
 
-    *res_ptr = calloc(step_number, sizeof(enum razer_mouse_res));
-    if (!*res_ptr)
-        return -ENOMEM;
+	step_number = DEATHADDER_CHROMA_MAX_RESOLUTION /
+		      DEATHADDER_CHROMA_RESOLUTION_STEP;
 
-    for (size_t i = 0; i < step_number; ++i)
-        (*res_ptr)[i] = (i + 1) * DEATHADDER_CHROMA_RESOLUTION_STEP;
+	*res_ptr = calloc(step_number, sizeof(enum razer_mouse_res));
+	if (!*res_ptr)
+		return -ENOMEM;
 
-    return step_number;
+	for (i = 0; i < step_number; ++i)
+		(*res_ptr)[i] = (i + 1) * DEATHADDER_CHROMA_RESOLUTION_STEP;
+
+	return step_number;
 }
 
 static int deathadder_chroma_supported_freqs(struct razer_mouse *m,
-                                             enum razer_mouse_freq **res_ptr)
+					     enum razer_mouse_freq **res_ptr)
 {
-    *res_ptr = calloc(DEATHADDER_CHROMA_SUPPORTED_FREQ_NUM,
-                      sizeof(enum razer_mouse_freq));
-    if (!*res_ptr)
-        return -ENOMEM;
+	*res_ptr = malloc(sizeof(deathadder_chroma_freqs_list));
+	if (!*res_ptr)
+		return -ENOMEM;
 
-    enum razer_mouse_freq freqs[] = {
-        RAZER_MOUSE_FREQ_125HZ,
-        RAZER_MOUSE_FREQ_500HZ,
-        RAZER_MOUSE_FREQ_1000HZ
-    };
-
-    static_assert(ARRAY_SIZE(freqs) == DEATHADDER_CHROMA_SUPPORTED_FREQ_NUM,
-                  "The size of supported frequencies array must equal the "
-                  "declared number of supported frequencies.");
-
-    memcpy(*res_ptr, freqs, sizeof(freqs));
-    return DEATHADDER_CHROMA_SUPPORTED_FREQ_NUM;
+	memcpy(*res_ptr, deathadder_chroma_freqs_list,
+	       sizeof(deathadder_chroma_freqs_list));
+	return DEATHADDER_CHROMA_SUPPORTED_FREQ_NUM;
 }
 
-static enum razer_mouse_freq deathadder_chroma_get_freq(
-        struct razer_mouse_profile *p)
+static enum razer_mouse_freq
+deathadder_chroma_get_freq(struct razer_mouse_profile *p)
 {
-    struct deathadder_chroma_driver_data *drv_data = p->mouse->drv_data;
-    return drv_data->current_freq;
+	struct deathadder_chroma_driver_data *drv_data;
+
+	drv_data = p->mouse->drv_data;
+	return drv_data->current_freq;
 }
 
-static struct razer_mouse_dpimapping *deathadder_chroma_get_dpimapping(
-        struct razer_mouse_profile *p, struct razer_axis *axis)
+static struct razer_mouse_dpimapping *
+deathadder_chroma_get_dpimapping(struct razer_mouse_profile *p,
+				 struct razer_axis *axis)
 {
-    struct deathadder_chroma_driver_data *drv_data = p->mouse->drv_data;
-    return drv_data->current_dpimapping;
+	struct deathadder_chroma_driver_data *drv_data;
+
+	drv_data = p->mouse->drv_data;
+	return drv_data->current_dpimapping;
 }
 
 static int deathadder_chroma_change_dpimapping(struct razer_mouse_dpimapping *d,
-                                               enum razer_dimension dim,
-                                               enum razer_mouse_res res)
+					       enum razer_dimension dim,
+					       enum razer_mouse_res res)
 {
-    if (!(d->dimension_mask | (1 << dim)))
-        return -EINVAL;
+	struct deathadder_chroma_driver_data *drv_data;
 
-    if (res == RAZER_MOUSE_RES_UNKNOWN)
-        res = RAZER_MOUSE_RES_1800DPI;
+	if (!(d->dimension_mask | (1 << dim)))
+		return -EINVAL;
 
-    if (res < RAZER_MOUSE_RES_100DPI || res > RAZER_MOUSE_RES_10000DPI)
-        return -EINVAL;
+	if (res == RAZER_MOUSE_RES_UNKNOWN)
+		res = RAZER_MOUSE_RES_1800DPI;
 
-    d->res[dim] = res;
+	if (res < RAZER_MOUSE_RES_100DPI || res > RAZER_MOUSE_RES_10000DPI)
+		return -EINVAL;
 
-    struct deathadder_chroma_driver_data *drv_data = d->mouse->drv_data;
-    if (d == drv_data->current_dpimapping)
-        return deathadder_chroma_send_set_resolution_command(d->mouse);
+	d->res[dim] = res;
 
-    return 0;
+	drv_data = d->mouse->drv_data;
+	if (d == drv_data->current_dpimapping)
+		return deathadder_chroma_send_set_resolution_command(d->mouse);
+
+	return 0;
 }
 
 static int deathadder_chroma_led_toggle_state(struct razer_led *led,
-                                              enum razer_led_state new_state)
+					      enum razer_led_state new_state)
 {
-    struct deathadder_chroma_driver_data *drv_data = led->u.mouse->drv_data;
-    struct deathadder_chroma_led *priv_led =
-            deathadder_chroma_get_led(drv_data, led->id);
+	struct deathadder_chroma_driver_data *drv_data;
+	struct deathadder_chroma_led *priv_led;
 
-    if (!priv_led)
-        return -EINVAL;
+	drv_data = led->u.mouse->drv_data;
+	priv_led = deathadder_chroma_get_led(drv_data, led->id);
 
-    switch (new_state) {
-        case RAZER_LED_UNKNOWN:
-        case RAZER_LED_ON:
-            priv_led->state = DEATHADDER_CHROMA_LED_STATE_ON;
-            break;
-        case RAZER_LED_OFF:
-            priv_led->state = DEATHADDER_CHROMA_LED_STATE_OFF;
-            break;
-    }
+	if (!priv_led)
+		return -EINVAL;
 
-    return deathadder_chroma_send_set_led_state_command(led->u.mouse, priv_led);
+	switch (new_state) {
+	case RAZER_LED_UNKNOWN:
+	case RAZER_LED_ON:
+		priv_led->state = DEATHADDER_CHROMA_LED_STATE_ON;
+		break;
+	case RAZER_LED_OFF:
+		priv_led->state = DEATHADDER_CHROMA_LED_STATE_OFF;
+		break;
+	}
+
+	return deathadder_chroma_send_set_led_state_command(led->u.mouse,
+							    priv_led);
 }
 
-static int deathadder_chroma_led_change_color(
-        struct razer_led *led, const struct razer_rgb_color *new_color)
+static int
+deathadder_chroma_led_change_color(struct razer_led *led,
+				   const struct razer_rgb_color *new_color)
 {
-    struct deathadder_chroma_driver_data *drv_data = led->u.mouse->drv_data;
-    struct deathadder_chroma_led *priv_led =
-            deathadder_chroma_get_led(drv_data, led->id);
+	struct deathadder_chroma_driver_data *drv_data;
+	struct deathadder_chroma_led *priv_led;
 
-    if (!priv_led)
-        return -EINVAL;
+	drv_data = led->u.mouse->drv_data;
+	priv_led = deathadder_chroma_get_led(drv_data, led->id);
 
-    if (priv_led->mode == DEATHADDER_CHROMA_LED_MODE_SPECTRUM)
-        return -EINVAL;
+	if (!priv_led)
+		return -EINVAL;
 
-    priv_led->color = (struct deathadder_chroma_rgb_color) {
-        .r = new_color->r,
-        .g = new_color->g,
-        .b = new_color->b
-    };
+	if (priv_led->mode == DEATHADDER_CHROMA_LED_MODE_SPECTRUM)
+		return -EINVAL;
 
-    return deathadder_chroma_send_set_led_color_command(led->u.mouse, priv_led);
+	priv_led->color = (struct deathadder_chroma_rgb_color){
+	    .r = new_color->r, .g = new_color->g, .b = new_color->b};
+
+	return deathadder_chroma_send_set_led_color_command(led->u.mouse,
+							    priv_led);
 }
-
 
 static int deathadder_chroma_set_freq(struct razer_mouse_profile *p,
-                                      enum razer_mouse_freq freq)
+				      enum razer_mouse_freq freq)
 {
-    if (freq == RAZER_MOUSE_FREQ_UNKNOWN)
-        freq = RAZER_MOUSE_FREQ_500HZ;
+	struct deathadder_chroma_driver_data *drv_data;
 
-    if (freq != RAZER_MOUSE_FREQ_125HZ && freq != RAZER_MOUSE_FREQ_500HZ &&
-        freq != RAZER_MOUSE_FREQ_1000HZ)
-        return -EINVAL;
+	if (freq == RAZER_MOUSE_FREQ_UNKNOWN)
+		freq = RAZER_MOUSE_FREQ_500HZ;
 
-    struct deathadder_chroma_driver_data *drv_data = p->mouse->drv_data;
-    drv_data->current_freq = freq;
+	if (freq != RAZER_MOUSE_FREQ_125HZ && freq != RAZER_MOUSE_FREQ_500HZ &&
+	    freq != RAZER_MOUSE_FREQ_1000HZ)
+		return -EINVAL;
 
-    return deathadder_chroma_send_set_frequency_command(p->mouse);
+	drv_data = p->mouse->drv_data;
+	drv_data->current_freq = freq;
+
+	return deathadder_chroma_send_set_frequency_command(p->mouse);
 }
 
 static int deathadder_chroma_set_dpimapping(struct razer_mouse_profile *p,
-                                            struct razer_axis *axis,
-                                            struct razer_mouse_dpimapping *d)
+					    struct razer_axis *axis,
+					    struct razer_mouse_dpimapping *d)
 {
-    if (axis && axis->id > 0)
-        return -EINVAL;
+	struct deathadder_chroma_driver_data *drv_data;
 
-    struct deathadder_chroma_driver_data *drv_data = p->mouse->drv_data;
-    drv_data->current_dpimapping = &drv_data->dpimappings[d->nr];
+	if (axis && axis->id > 0)
+		return -EINVAL;
 
-    return deathadder_chroma_send_set_resolution_command(p->mouse);
+	drv_data = p->mouse->drv_data;
+	drv_data->current_dpimapping = &drv_data->dpimappings[d->nr];
+
+	return deathadder_chroma_send_set_resolution_command(p->mouse);
 }
 
-static int deathadder_chroma_translate_led_mode(
-        enum deathadder_chroma_led_mode mode)
+static int
+deathadder_chroma_translate_led_mode(enum deathadder_chroma_led_mode mode)
 {
-    switch (mode) {
-        case DEATHADDER_CHROMA_LED_MODE_STATIC:
-            return RAZER_LED_MODE_STATIC;
-        case DEATHADDER_CHROMA_LED_MODE_BREATHING:
-            return RAZER_LED_MODE_BREATHING;
-        case DEATHADDER_CHROMA_LED_MODE_SPECTRUM:
-            return RAZER_LED_MODE_SPECTRUM;
-        default:
-            return -EINVAL;
-    }
+	switch (mode) {
+	case DEATHADDER_CHROMA_LED_MODE_STATIC:
+		return RAZER_LED_MODE_STATIC;
+	case DEATHADDER_CHROMA_LED_MODE_BREATHING:
+		return RAZER_LED_MODE_BREATHING;
+	case DEATHADDER_CHROMA_LED_MODE_SPECTRUM:
+		return RAZER_LED_MODE_SPECTRUM;
+	default:
+		return -EINVAL;
+	}
 }
 
 static int deathadder_chroma_translate_razer_led_mode(enum razer_led_mode mode)
 {
-    switch (mode) {
-        case RAZER_LED_MODE_STATIC:
-            return DEATHADDER_CHROMA_LED_MODE_STATIC;
-        case RAZER_LED_MODE_BREATHING:
-            return DEATHADDER_CHROMA_LED_MODE_BREATHING;
-        case RAZER_LED_MODE_SPECTRUM:
-            return DEATHADDER_CHROMA_LED_MODE_SPECTRUM;
-        default:
-            return -EINVAL;
-    }
+	switch (mode) {
+	case RAZER_LED_MODE_STATIC:
+		return DEATHADDER_CHROMA_LED_MODE_STATIC;
+	case RAZER_LED_MODE_BREATHING:
+		return DEATHADDER_CHROMA_LED_MODE_BREATHING;
+	case RAZER_LED_MODE_SPECTRUM:
+		return DEATHADDER_CHROMA_LED_MODE_SPECTRUM;
+	default:
+		return -EINVAL;
+	}
 }
 
 static int deathadder_chroma_led_set_mode(struct razer_led *led,
-                                          enum razer_led_mode new_mode)
+					  enum razer_led_mode new_mode)
 {
-    struct deathadder_chroma_driver_data *drv_data = led->u.mouse->drv_data;
-    struct deathadder_chroma_led *priv_led =
-            deathadder_chroma_get_led(drv_data, led->id);
+	int err;
+	struct deathadder_chroma_driver_data *drv_data;
+	struct deathadder_chroma_led *priv_led;
 
-    if (!priv_led)
-        return -EINVAL;
+	drv_data = led->u.mouse->drv_data;
+	priv_led = deathadder_chroma_get_led(drv_data, led->id);
 
-    int err = deathadder_chroma_translate_razer_led_mode(new_mode);
-    if (err < 0)
-        return err;
+	if (!priv_led)
+		return -EINVAL;
 
-    priv_led->mode = err;
-    return deathadder_chroma_send_set_led_mode_command(led->u.mouse, priv_led);
+	err = deathadder_chroma_translate_razer_led_mode(new_mode);
+	if (err < 0)
+		return err;
+
+	priv_led->mode = err;
+	return deathadder_chroma_send_set_led_mode_command(led->u.mouse,
+							   priv_led);
 }
 
 static int deathadder_chroma_get_leds(struct razer_mouse *m,
-                                      struct razer_led **leds_list)
+				      struct razer_led **leds_list)
 {
-    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
+	unsigned int supported_modes;
+	enum razer_led_state scroll_state, logo_state;
+	struct deathadder_chroma_driver_data *drv_data;
+	struct razer_led *scroll, *logo;
 
-    struct razer_led *scroll = zalloc(sizeof(struct razer_led));
-    if (!scroll)
-        return -ENOMEM;
+	drv_data = m->drv_data;
 
-    struct razer_led *logo = zalloc(sizeof(struct razer_led));
-    if (!logo) {
-        free(scroll);
-        return -ENOMEM;
-    }
+	scroll = zalloc(sizeof(struct razer_led));
+	if (!scroll)
+		return -ENOMEM;
 
-    unsigned int supported_modes = (1 << RAZER_LED_MODE_BREATHING) |
-            (1 << RAZER_LED_MODE_SPECTRUM) | (1 << RAZER_LED_MODE_STATIC);
+	logo = zalloc(sizeof(struct razer_led));
+	if (!logo) {
+		free(scroll);
+		return -ENOMEM;
+	}
 
-    enum razer_led_state scroll_state =
-            drv_data->scroll_led.state == DEATHADDER_CHROMA_LED_STATE_OFF
-            ? RAZER_LED_OFF : RAZER_LED_ON;
+	supported_modes = (1 << RAZER_LED_MODE_BREATHING) |
+			  (1 << RAZER_LED_MODE_SPECTRUM) |
+			  (1 << RAZER_LED_MODE_STATIC);
 
-    *scroll = (struct razer_led) {
-        .id           = drv_data->scroll_led.id,
-        .name         = DEATHADDER_CHROMA_SCROLL_NAME,
-        .state        = scroll_state,
-        .u.mouse      = m,
-        .toggle_state = deathadder_chroma_led_toggle_state,
-        .change_color = deathadder_chroma_led_change_color,
-        .set_mode     = deathadder_chroma_led_set_mode,
-        .next         = logo,
-        .color        = {
-            .r = drv_data->scroll_led.color.r,
-            .g = drv_data->scroll_led.color.g,
-            .b = drv_data->scroll_led.color.b,
-            .valid = 1
-        },
-        .mode = deathadder_chroma_translate_led_mode(drv_data->scroll_led.mode),
-        .supported_modes_mask = supported_modes
-    };
+	scroll_state =
+	    drv_data->scroll_led.state == DEATHADDER_CHROMA_LED_STATE_OFF
+		? RAZER_LED_OFF
+		: RAZER_LED_ON;
 
-    enum razer_led_state logo_state =
-            drv_data->logo_led.state == DEATHADDER_CHROMA_LED_STATE_OFF
-            ? RAZER_LED_OFF : RAZER_LED_ON;
+	*scroll = (struct razer_led){
+	    .id = drv_data->scroll_led.id,
+	    .name = DEATHADDER_CHROMA_SCROLL_NAME,
+	    .state = scroll_state,
+	    .u.mouse = m,
+	    .toggle_state = deathadder_chroma_led_toggle_state,
+	    .change_color = deathadder_chroma_led_change_color,
+	    .set_mode = deathadder_chroma_led_set_mode,
+	    .next = logo,
+	    .color = {.r = drv_data->scroll_led.color.r,
+		      .g = drv_data->scroll_led.color.g,
+		      .b = drv_data->scroll_led.color.b,
+		      .valid = 1},
+	    .supported_modes_mask = supported_modes,
+	    .mode = deathadder_chroma_translate_led_mode(
+		drv_data->scroll_led.mode)};
 
-    *logo = (struct razer_led) {
-        .id           = drv_data->logo_led.id,
-        .name         = DEATHADDER_CHROMA_LOGO_NAME,
-        .state        = logo_state,
-        .u.mouse      = m,
-        .toggle_state = deathadder_chroma_led_toggle_state,
-        .change_color = deathadder_chroma_led_change_color,
-        .set_mode     = deathadder_chroma_led_set_mode,
-        .color        = {
-            .r = drv_data->logo_led.color.r,
-            .g = drv_data->logo_led.color.g,
-            .b = drv_data->logo_led.color.b,
-            .valid = 1
-        },
-        .mode = deathadder_chroma_translate_led_mode(drv_data->logo_led.mode),
-        .supported_modes_mask = supported_modes
-    };
+	logo_state = drv_data->logo_led.state == DEATHADDER_CHROMA_LED_STATE_OFF
+			 ? RAZER_LED_OFF
+			 : RAZER_LED_ON;
 
-    *leds_list = scroll;
-    return DEATHADDER_CHROMA_LED_NUM;
+	*logo = (struct razer_led){
+	    .id = drv_data->logo_led.id,
+	    .name = DEATHADDER_CHROMA_LOGO_NAME,
+	    .state = logo_state,
+	    .u.mouse = m,
+	    .toggle_state = deathadder_chroma_led_toggle_state,
+	    .change_color = deathadder_chroma_led_change_color,
+	    .set_mode = deathadder_chroma_led_set_mode,
+	    .color = {.r = drv_data->logo_led.color.r,
+		      .g = drv_data->logo_led.color.g,
+		      .b = drv_data->logo_led.color.b,
+		      .valid = 1},
+	    .supported_modes_mask = supported_modes,
+	    .mode =
+		deathadder_chroma_translate_led_mode(drv_data->logo_led.mode)};
+
+	*leds_list = scroll;
+	return DEATHADDER_CHROMA_LED_NUM;
 }
 
 int razer_deathadder_chroma_init(struct razer_mouse *m,
-                                 struct libusb_device *usbdev)
+				 struct libusb_device *usbdev)
 {
-    struct deathadder_chroma_driver_data *drv_data = zalloc(sizeof(*drv_data));
-    if (!drv_data)
-        return -ENOMEM;
+	int err;
+	size_t i;
+	struct deathadder_chroma_driver_data *drv_data;
+	struct deathadder_chroma_led *scroll_led, *logo_led;
 
-    razer_event_spacing_init(&drv_data->packet_spacing,
-                             DEATHADDER_CHROMA_PACKET_SPACING_MS);
+	drv_data = zalloc(sizeof(*drv_data));
+	if (!drv_data)
+		return -ENOMEM;
 
-    enum razer_mouse_res resolution_stages[] = {
-        RAZER_MOUSE_RES_800DPI,
-        RAZER_MOUSE_RES_1800DPI,
-        RAZER_MOUSE_RES_3500DPI,
-        RAZER_MOUSE_RES_5600DPI,
-        RAZER_MOUSE_RES_10000DPI
-    };
+	razer_event_spacing_init(&drv_data->packet_spacing,
+				 DEATHADDER_CHROMA_PACKET_SPACING_MS);
 
-    static_assert(ARRAY_SIZE(resolution_stages) ==
-                  DEATHADDER_CHROMA_DPIMAPPINGS_NUM,
-                  "The number of resolution stages must equal the declared "
-                  "number of dpi mappings.");
+	for (i = 0; i < DEATHADDER_CHROMA_DPIMAPPINGS_NUM; ++i) {
+		drv_data->dpimappings[i] = (struct razer_mouse_dpimapping){
+		    .nr = i,
+		    .change = deathadder_chroma_change_dpimapping,
+		    .dimension_mask = (1 << RAZER_DIM_X) | (1 << RAZER_DIM_Y),
+		    .mouse = m};
 
-    for (int i = 0; i < DEATHADDER_CHROMA_DPIMAPPINGS_NUM; ++i) {
-        drv_data->dpimappings[i] = (struct razer_mouse_dpimapping) {
-            .nr             = i,
-            .change         = deathadder_chroma_change_dpimapping,
-            .dimension_mask = (1 << RAZER_DIM_X) | (1 << RAZER_DIM_Y),
-            .mouse          = m
-        };
+		drv_data->dpimappings[i].res[RAZER_DIM_X] =
+		    drv_data->dpimappings[i].res[RAZER_DIM_Y] =
+			deathadder_chroma_resolution_stages_list[i];
+	}
 
-        drv_data->dpimappings[i].res[RAZER_DIM_X] =
-                drv_data->dpimappings[i].res[RAZER_DIM_Y] =
-                    resolution_stages[i];
-    }
+	drv_data->current_dpimapping = &drv_data->dpimappings[1];
+	drv_data->current_freq = RAZER_MOUSE_FREQ_500HZ;
 
-    drv_data->current_dpimapping = &drv_data->dpimappings[1];
-    drv_data->current_freq = RAZER_MOUSE_FREQ_500HZ;
+	drv_data->scroll_led = (struct deathadder_chroma_led){
+	    .id = DEATHADDER_CHROMA_LED_ID_SCROLL,
+	    .mode = DEATHADDER_CHROMA_LED_MODE_SPECTRUM,
+	    .state = DEATHADDER_CHROMA_LED_STATE_ON,
+	    .color = {0x00, 0xFF, 0x00}};
 
-    drv_data->scroll_led = (struct deathadder_chroma_led) {
-        .id    = DEATHADDER_CHROMA_LED_ID_SCROLL,
-        .mode  = DEATHADDER_CHROMA_LED_MODE_SPECTRUM,
-        .state = DEATHADDER_CHROMA_LED_STATE_ON,
-        .color = { 0x00, 0xFF, 0x00 }
-    };
+	drv_data->logo_led = (struct deathadder_chroma_led){
+	    .id = DEATHADDER_CHROMA_LED_ID_LOGO,
+	    .mode = DEATHADDER_CHROMA_LED_MODE_SPECTRUM,
+	    .state = DEATHADDER_CHROMA_LED_STATE_ON,
+	    .color = {0x00, 0xFF, 0x00}};
 
-    drv_data->logo_led = (struct deathadder_chroma_led) {
-        .id    = DEATHADDER_CHROMA_LED_ID_LOGO,
-        .mode  = DEATHADDER_CHROMA_LED_MODE_SPECTRUM,
-        .state = DEATHADDER_CHROMA_LED_STATE_ON,
-        .color = { 0x00, 0xFF, 0x00 }
-    };
+	razer_init_axes(drv_data->axes, "X/Y",
+			RAZER_AXIS_INDEPENDENT_DPIMAPPING, "Scroll", 0, NULL,
+			0);
 
-    razer_init_axes(drv_data->axes,
-                    "X/Y", RAZER_AXIS_INDEPENDENT_DPIMAPPING,
-                    "Scroll", 0,
-                    NULL, 0);
+	m->drv_data = drv_data;
 
-    m->drv_data = drv_data;
+	if ((err = razer_usb_add_used_interface(m->usb_ctx, 0, 0)) ||
+	    (err = m->claim(m))) {
+		free(drv_data);
+		return err;
+	}
 
-    int err;
-    if ((err = razer_usb_add_used_interface(m->usb_ctx, 0, 0)) ||
-        (err = m->claim(m)))
-    {
-        free(drv_data);
-        return err;
-    }
+	scroll_led = &drv_data->scroll_led;
+	logo_led = &drv_data->logo_led;
 
-    struct deathadder_chroma_led *scroll_led = &drv_data->scroll_led;
-    struct deathadder_chroma_led *logo_led   = &drv_data->logo_led;
+	if ((err = deathadder_chroma_send_init_command(m)) ||
+	    (err = deathadder_chroma_send_set_resolution_command(m)) ||
+	    (err = deathadder_chroma_send_get_firmware_command(m)) ||
+	    (err = deathadder_chroma_send_get_serial_no_command(m)) ||
+	    (err = deathadder_chroma_send_set_frequency_command(m)) ||
+	    (err =
+		 deathadder_chroma_send_set_led_state_command(m, scroll_led)) ||
+	    (err =
+		 deathadder_chroma_send_set_led_mode_command(m, scroll_led)) ||
+	    (err =
+		 deathadder_chroma_send_set_led_color_command(m, scroll_led)) ||
+	    (err = deathadder_chroma_send_set_led_state_command(m, logo_led)) ||
+	    (err = deathadder_chroma_send_set_led_mode_command(m, logo_led)) ||
+	    (err = deathadder_chroma_send_set_led_color_command(m, logo_led))) {
+		m->release(m);
+		free(drv_data);
+		return err;
+	}
 
-    if ((err = deathadder_chroma_send_init_command          (m)) ||
-        (err = deathadder_chroma_send_set_resolution_command(m)) ||
-        (err = deathadder_chroma_send_get_firmware_command  (m)) ||
-        (err = deathadder_chroma_send_get_serial_no_command (m)) ||
-        (err = deathadder_chroma_send_set_frequency_command (m)) ||
-        (err = deathadder_chroma_send_set_led_state_command (m, scroll_led)) ||
-        (err = deathadder_chroma_send_set_led_mode_command  (m, scroll_led)) ||
-        (err = deathadder_chroma_send_set_led_color_command (m, scroll_led)) ||
-        (err = deathadder_chroma_send_set_led_state_command (m, logo_led)) ||
-        (err = deathadder_chroma_send_set_led_mode_command  (m, logo_led)) ||
-        (err = deathadder_chroma_send_set_led_color_command (m, logo_led)))
-    {
-        m->release(m);
-        free(drv_data);
-        return err;
-    }
+	m->release(m);
 
-    m->release(m);
+	drv_data->profile = (struct razer_mouse_profile){
+	    .mouse = m,
+	    .get_freq = deathadder_chroma_get_freq,
+	    .set_freq = deathadder_chroma_set_freq,
+	    .get_dpimapping = deathadder_chroma_get_dpimapping,
+	    .set_dpimapping = deathadder_chroma_set_dpimapping};
 
-    drv_data->profile = (struct razer_mouse_profile) {
-        .mouse          = m,
-        .get_freq       = deathadder_chroma_get_freq,
-        .set_freq       = deathadder_chroma_set_freq,
-        .get_dpimapping = deathadder_chroma_get_dpimapping,
-        .set_dpimapping = deathadder_chroma_set_dpimapping
-    };
+	razer_generic_usb_gen_idstr(usbdev, m->usb_ctx->h,
+				    DEATHADDER_CHROMA_DEVICE_NAME, false,
+				    drv_data->serial, m->idstr);
 
-    razer_generic_usb_gen_idstr(usbdev, m->usb_ctx->h,
-                                DEATHADDER_CHROMA_DEVICE_NAME, false,
-                                drv_data->serial, m->idstr);
+	m->type = RAZER_MOUSETYPE_DEATHADDER;
+	m->get_fw_version = deathadder_chroma_get_fw_version;
+	m->global_get_leds = deathadder_chroma_get_leds;
+	m->get_profiles = deathadder_chroma_get_profiles;
+	m->supported_axes = deathadder_chroma_supported_axes;
+	m->supported_resolutions = deathadder_chroma_supported_resolutions;
+	m->supported_freqs = deathadder_chroma_supported_freqs;
+	m->supported_dpimappings = deathadder_chroma_supported_dpimappings;
 
-    m->type                  = RAZER_MOUSETYPE_DEATHADDER;
-    m->get_fw_version        = deathadder_chroma_get_fw_version;
-    m->global_get_leds       = deathadder_chroma_get_leds;
-    m->get_profiles          = deathadder_chroma_get_profiles;
-    m->supported_axes        = deathadder_chroma_supported_axes;
-    m->supported_resolutions = deathadder_chroma_supported_resolutions;
-    m->supported_freqs       = deathadder_chroma_supported_freqs;
-    m->supported_dpimappings = deathadder_chroma_supported_dpimappings;
-
-    return 0;
+	return 0;
 }
 
 void razer_deathadder_chroma_release(struct razer_mouse *m)
 {
-    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
-    free(drv_data);
-    m->drv_data = NULL;
+	struct deathadder_chroma_driver_data *drv_data;
+
+	drv_data = m->drv_data;
+	free(drv_data);
+	m->drv_data = NULL;
 }

--- a/librazer/hw_deathadder_chroma.c
+++ b/librazer/hw_deathadder_chroma.c
@@ -1,0 +1,790 @@
+/*
+ * Lowlevel hardware access for the Razer DeathAdder Chroma mouse.
+ *
+ * Important notice:
+ * This hardware driver is based on reverse engineering, only.
+ *
+ * Copyright (C) 2015 Konrad Zemek <konrad.zemek@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ */
+
+#include "hw_deathadder_chroma.h"
+#include "razer_private.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#define DEATHADDER_CHROMA_DEVICE_NAME    "DeathAdder Chroma"
+#define DEATHADDER_CHROMA_SCROLL_NAME    "Scroll"
+#define DEATHADDER_CHROMA_LOGO_NAME      "GlowingLogo"
+#define DEATHADDER_CHROMA_STATIC_NAME    "Static"
+#define DEATHADDER_CHROMA_SPECTRUM_NAME  "Spectrum"
+#define DEATHADDER_CHROMA_BREATHING_NAME "Breathing"
+
+enum deathadder_chroma_led_id
+{
+    DEATHADDER_CHROMA_LED_ID_SCROLL = 0x01,
+    DEATHADDER_CHROMA_LED_ID_LOGO   = 0x04
+};
+
+enum deathadder_chroma_led_mode
+{
+    DEATHADDER_CHROMA_LED_MODE_STATIC    = 0x00,
+    DEATHADDER_CHROMA_LED_MODE_BREATHING = 0x02,
+    DEATHADDER_CHROMA_LED_MODE_SPECTRUM  = 0X04
+};
+
+enum deathadder_chroma_led_state
+{
+    DEATHADDER_CHROMA_LED_STATE_OFF = 0x00,
+    DEATHADDER_CHROMA_LED_STATE_ON  = 0x01
+};
+
+/*
+ * The 6th byte of DeathAdder Chroma's command seems to be the size of arguments
+ * (size of arguments to read in case of read operations). It's not necessarily
+ * so, since some values are slightly off (i.e. bigger than the apparent size
+ * of the arguments).
+ * Experiments suggest that the value given in the 'size' byte does not matter.
+ * I chose to go with the values used by the Synapse driver.
+ */
+enum deathadder_chroma_request_size
+{
+    DEATHADDER_CHROMA_REQUEST_SIZE_INIT           = 0x02,
+    DEATHADDER_CHROMA_REQUEST_SIZE_SET_RESOLUTION = 0x07,
+    DEATHADDER_CHROMA_REQUEST_SIZE_GET_FIRMWARE   = 0x04,
+    DEATHADDER_CHROMA_REQUEST_SIZE_GET_SERIAL_NO  = 0x16,
+    DEATHADDER_CHROMA_REQUEST_SIZE_SET_FREQUENCY  = 0x01,
+    DEATHADDER_CHROMA_REQUEST_SIZE_SET_LED_STATE  = 0x03,
+    DEATHADDER_CHROMA_REQUEST_SIZE_SET_LED_MODE   = 0x03,
+    DEATHADDER_CHROMA_REQUEST_SIZE_SET_LED_COLOR  = 0x05
+};
+
+enum deathadder_chroma_request
+{
+    DEATHADDER_CHROMA_REQUEST_INIT           = 0x0004,
+    DEATHADDER_CHROMA_REQUEST_SET_RESOLUTION = 0x0405,
+    DEATHADDER_CHROMA_REQUEST_GET_FIRMWARE   = 0x0087,
+    DEATHADDER_CHROMA_REQUEST_GET_SERIAL_NO  = 0x0082,
+    DEATHADDER_CHROMA_REQUEST_SET_FREQUENCY  = 0x0005,
+    DEATHADDER_CHROMA_REQUEST_SET_LED_STATE  = 0x0300,
+    DEATHADDER_CHROMA_REQUEST_SET_LED_MODE   = 0x0302,
+    DEATHADDER_CHROMA_REQUEST_SET_LED_COLOR  = 0x0301
+};
+
+enum
+{
+    DEATHADDER_CHROMA_MAX_FREQUENCY           = RAZER_MOUSE_FREQ_1000HZ,
+    DEATHADDER_CHROMA_MAX_RESOLUTION          = RAZER_MOUSE_RES_10000DPI,
+    DEATHADDER_CHROMA_RESOLUTION_STEP         = RAZER_MOUSE_RES_100DPI,
+    DEATHADDER_CHROMA_SUPPORTED_FREQ_NUM      = 3,
+    DEATHADDER_CHROMA_LED_NUM                 = 2,
+    DEATHADDER_CHROMA_AXES_NUM                = 2,
+    DEATHADDER_CHROMA_DPIMAPPINGS_NUM         = 5,
+
+    DEATHADDER_CHROMA_USB_SETUP_PACKET_VALUE  = 0x300,
+    DEATHADDER_CHROMA_SUCCESS_STATUS          = 0x02,
+    DEATHADDER_CHROMA_PACKET_SPACING_MS       = 35,
+
+    /*
+     * Experiments suggest that the value in the 'magic' byte of the command
+     * does not necessarily matter (e.g. the commands work when the 'magic' byte
+     * equals 0x77). I chose to go with the value used by the Synapse driver.
+     */
+    DEATHADDER_CHROMA_MAGIC_BYTE = 0xFF,
+
+    /*
+     * These specific arg0 bytes are used by the Synapse driver for their
+     * respective commands. Their value may or may not matter (e.g. matters in
+     * the case of LED commands, doesn't seem to matter for the resolution
+     * command).
+     */
+    DEATHADDER_CHROMA_LED_ARG0        = 0x01,
+    DEATHADDER_CHROMA_INIT_ARG0       = 0x03,
+    DEATHADDER_CHROMA_RESOLUTION_ARG0 = 0x00
+};
+
+struct deathadder_chroma_command
+{
+    uint8_t status;
+    uint8_t magic;
+    uint8_t padding0[3];
+    uint8_t size;
+    be16_t  request;
+
+    union {
+        uint8_t bvalue[80];
+        be32_t  lvalue[20];
+        struct {
+            uint8_t padding1;
+            be16_t  value[38];
+            uint8_t padding2;
+        } _packed;
+    } _packed;
+
+    uint8_t checksum;
+    uint8_t padding3;
+} _packed;
+
+static_assert(sizeof(struct deathadder_chroma_command) == 90,
+              "The size of deathadder_chroma_command structure "
+              "must equal 90 bytes.");
+
+#define DEATHADDER_CHROMA_COMMAND_INIT                                         \
+    (struct deathadder_chroma_command) { .magic = DEATHADDER_CHROMA_MAGIC_BYTE }
+
+struct deathadder_chroma_rgb_color
+{
+    uint8_t r;
+    uint8_t g;
+    uint8_t b;
+};
+
+struct deathadder_chroma_led
+{
+    enum deathadder_chroma_led_id id;
+    enum deathadder_chroma_led_mode mode;
+    enum deathadder_chroma_led_state state;
+    struct deathadder_chroma_rgb_color color;
+};
+
+struct deathadder_chroma_driver_data
+{
+    uint32_t fw_version;
+    char serial[DEATHADDER_CHROMA_REQUEST_SIZE_GET_SERIAL_NO];
+    struct razer_event_spacing packet_spacing;
+    struct razer_mouse_dpimapping *current_dpimapping;
+    struct razer_mouse_dpimapping dpimappings[DEATHADDER_CHROMA_DPIMAPPINGS_NUM];
+    struct deathadder_chroma_led scroll_led;
+    struct deathadder_chroma_led logo_led;
+    enum razer_mouse_freq current_freq;
+    struct razer_mouse_profile profile;
+    struct razer_axis axes[DEATHADDER_CHROMA_AXES_NUM];
+};
+
+static uint8_t deathadder_chroma_checksum(struct deathadder_chroma_command *cmd)
+{
+    size_t control_size = sizeof(cmd->size) + sizeof(cmd->request);
+    return razer_xor8_checksum((uint8_t*) &cmd->size, control_size + cmd->size);
+}
+
+static int deathadder_chroma_translate_frequency(enum razer_mouse_freq freq)
+{
+    switch (freq) {
+        case RAZER_MOUSE_FREQ_UNKNOWN:
+            freq = RAZER_MOUSE_FREQ_500HZ;
+
+        case RAZER_MOUSE_FREQ_125HZ:
+        case RAZER_MOUSE_FREQ_500HZ:
+        case RAZER_MOUSE_FREQ_1000HZ:
+            return DEATHADDER_CHROMA_MAX_FREQUENCY / freq;
+
+        default:
+            return -EINVAL;
+    }
+}
+
+static int deathadder_chroma_usb_action(
+        struct razer_mouse *m, enum libusb_endpoint_direction direction,
+        enum libusb_standard_request request, uint16_t command,
+        struct deathadder_chroma_command *cmd)
+{
+    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
+
+    razer_event_spacing_enter(&drv_data->packet_spacing);
+    int err = libusb_control_transfer(
+                m->usb_ctx->h,
+                direction | LIBUSB_REQUEST_TYPE_CLASS |
+                LIBUSB_RECIPIENT_INTERFACE,
+                request, command, 0, (unsigned char*) cmd, sizeof(*cmd),
+                RAZER_USB_TIMEOUT);
+    razer_event_spacing_leave(&drv_data->packet_spacing);
+
+    if (err != sizeof(*cmd)) {
+        razer_error("razer-deathadder-chroma: "
+                    "USB %s 0x%01X 0x%02X failed with %d\n",
+                    direction == LIBUSB_ENDPOINT_IN ? "read" : "write",
+                    request, command, err);
+        return err;
+    }
+
+    return 0;
+}
+
+static int deathadder_chroma_send_command(struct razer_mouse *m,
+                                          struct deathadder_chroma_command *cmd)
+{
+    cmd->checksum = deathadder_chroma_checksum(cmd);
+    int err = deathadder_chroma_usb_action(
+                m, LIBUSB_ENDPOINT_OUT, LIBUSB_REQUEST_SET_CONFIGURATION,
+                DEATHADDER_CHROMA_USB_SETUP_PACKET_VALUE, cmd);
+    if (err)
+        return err;
+
+    err = deathadder_chroma_usb_action(
+                m, LIBUSB_ENDPOINT_IN, LIBUSB_REQUEST_CLEAR_FEATURE,
+                DEATHADDER_CHROMA_USB_SETUP_PACKET_VALUE, cmd);
+    if (err)
+        return err;
+
+    uint8_t checksum = deathadder_chroma_checksum(cmd);
+    if (checksum != cmd->checksum)
+    {
+        razer_error("razer-deathadder-chroma: "
+                    "Command %02X %04X bad response checksum %02X "
+                    "(expected %02X)\n", cmd->size, be16_to_cpu(cmd->request),
+                    checksum, cmd->checksum);
+
+        return -EBADMSG;
+    }
+
+    if (cmd->status != DEATHADDER_CHROMA_SUCCESS_STATUS)
+        razer_error("razer-deathadder-chroma: "
+                    "Command %02X %04X failed with %02X\n",
+                    cmd->size, be16_to_cpu(cmd->request), cmd->status);
+
+    return 0;
+}
+
+static int deathadder_chroma_send_init_command(struct razer_mouse *m)
+{
+    struct deathadder_chroma_command cmd = DEATHADDER_CHROMA_COMMAND_INIT;
+    cmd.size      = DEATHADDER_CHROMA_REQUEST_SIZE_INIT;
+    cmd.request   = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_INIT);
+    cmd.bvalue[0] = DEATHADDER_CHROMA_INIT_ARG0;
+    return deathadder_chroma_send_command(m, &cmd);
+}
+
+static int deathadder_chroma_send_set_resolution_command(struct razer_mouse *m)
+{
+    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
+    enum razer_mouse_res res_x = drv_data->current_dpimapping->res[RAZER_DIM_X];
+    enum razer_mouse_res res_y = drv_data->current_dpimapping->res[RAZER_DIM_Y];
+
+    struct deathadder_chroma_command cmd = DEATHADDER_CHROMA_COMMAND_INIT;
+    cmd.size      = DEATHADDER_CHROMA_REQUEST_SIZE_SET_RESOLUTION;
+    cmd.request   = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_SET_RESOLUTION);
+    cmd.bvalue[0] = DEATHADDER_CHROMA_RESOLUTION_ARG0;
+    cmd.value[0]  = cpu_to_be16(res_x);
+    cmd.value[1]  = cpu_to_be16(res_y);
+    return deathadder_chroma_send_command(m, &cmd);
+}
+
+static int deathadder_chroma_send_get_firmware_command(struct razer_mouse *m)
+{
+    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
+    struct deathadder_chroma_command cmd = DEATHADDER_CHROMA_COMMAND_INIT;
+    cmd.size    = DEATHADDER_CHROMA_REQUEST_SIZE_GET_FIRMWARE;
+    cmd.request = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_GET_FIRMWARE);
+
+    int err = deathadder_chroma_send_command(m, &cmd);
+    if (err)
+        return err;
+
+    drv_data->fw_version = be32_to_cpu(cmd.lvalue[0]);
+    return 0;
+}
+
+static int deathadder_chroma_send_get_serial_no_command(struct razer_mouse *m)
+{
+    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
+    struct deathadder_chroma_command cmd = DEATHADDER_CHROMA_COMMAND_INIT;
+    cmd.size    = DEATHADDER_CHROMA_REQUEST_SIZE_GET_SERIAL_NO;
+    cmd.request = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_GET_SERIAL_NO);
+
+    int err = deathadder_chroma_send_command(m, &cmd);
+    if (err)
+        return err;
+
+    strncpy(drv_data->serial, (const char *) cmd.bvalue,
+            DEATHADDER_CHROMA_REQUEST_SIZE_GET_SERIAL_NO);
+    return 0;
+}
+
+static int deathadder_chroma_send_set_frequency_command(struct razer_mouse *m)
+{
+    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
+    struct deathadder_chroma_command cmd = DEATHADDER_CHROMA_COMMAND_INIT;
+    int tfreq = deathadder_chroma_translate_frequency(drv_data->current_freq);
+    if (tfreq < 0)
+        return tfreq;
+
+    cmd.size      = DEATHADDER_CHROMA_REQUEST_SIZE_SET_FREQUENCY;
+    cmd.request   = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_SET_FREQUENCY);
+    cmd.bvalue[0] = tfreq;
+    return deathadder_chroma_send_command(m, &cmd);
+}
+
+static struct deathadder_chroma_led *deathadder_chroma_get_led(
+        struct deathadder_chroma_driver_data *d,
+        enum deathadder_chroma_led_id led_id)
+{
+    switch (led_id) {
+        case DEATHADDER_CHROMA_LED_ID_LOGO:   return &d->logo_led;
+        case DEATHADDER_CHROMA_LED_ID_SCROLL: return &d->scroll_led;
+        default: return NULL;
+    }
+}
+
+static int deathadder_chroma_send_set_led_state_command(
+        struct razer_mouse *m, struct deathadder_chroma_led *led)
+{
+    struct deathadder_chroma_command cmd = DEATHADDER_CHROMA_COMMAND_INIT;
+    cmd.size      = DEATHADDER_CHROMA_REQUEST_SIZE_SET_LED_STATE;
+    cmd.request   = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_SET_LED_STATE);
+    cmd.bvalue[0] = DEATHADDER_CHROMA_LED_ARG0;
+    cmd.bvalue[1] = led->id;
+    cmd.bvalue[2] = led->state;
+    return deathadder_chroma_send_command(m, &cmd);
+}
+
+static int deathadder_chroma_send_set_led_mode_command(
+        struct razer_mouse *m, struct deathadder_chroma_led *led)
+{
+    struct deathadder_chroma_command cmd = DEATHADDER_CHROMA_COMMAND_INIT;
+    cmd.size      = DEATHADDER_CHROMA_REQUEST_SIZE_SET_LED_MODE;
+    cmd.request   = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_SET_LED_MODE);
+    cmd.bvalue[0] = DEATHADDER_CHROMA_LED_ARG0;
+    cmd.bvalue[1] = led->id;
+    cmd.bvalue[2] = led->mode;
+    return deathadder_chroma_send_command(m, &cmd);
+}
+
+static int deathadder_chroma_send_set_led_color_command(
+        struct razer_mouse *m, struct deathadder_chroma_led *led)
+{
+    struct deathadder_chroma_command cmd = DEATHADDER_CHROMA_COMMAND_INIT;
+    cmd.size      = DEATHADDER_CHROMA_REQUEST_SIZE_SET_LED_COLOR;
+    cmd.request   = cpu_to_be16(DEATHADDER_CHROMA_REQUEST_SET_LED_COLOR);
+    cmd.bvalue[0] = DEATHADDER_CHROMA_LED_ARG0;
+    cmd.bvalue[1] = led->id;
+    cmd.bvalue[2] = led->color.r;
+    cmd.bvalue[3] = led->color.g;
+    cmd.bvalue[4] = led->color.b;
+    return deathadder_chroma_send_command(m, &cmd);
+}
+
+static int deathadder_chroma_get_fw_version(struct razer_mouse *m)
+{
+    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
+    return drv_data->fw_version;
+}
+
+static struct razer_mouse_profile *deathadder_chroma_get_profiles(
+        struct razer_mouse *m)
+{
+    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
+    return &drv_data->profile;
+}
+
+static int deathadder_chroma_supported_axes(
+        struct razer_mouse *m, struct razer_axis **res_ptr)
+{
+    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
+    *res_ptr = drv_data->axes;
+    return ARRAY_SIZE(drv_data->axes);
+}
+
+static int deathadder_chroma_supported_dpimappings(
+        struct razer_mouse *m, struct razer_mouse_dpimapping **res_ptr)
+{
+    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
+    *res_ptr = drv_data->dpimappings;
+    return ARRAY_SIZE(drv_data->dpimappings);
+}
+
+static int deathadder_chroma_supported_resolutions(
+        struct razer_mouse *m, enum razer_mouse_res **res_ptr)
+{
+    size_t step_number = DEATHADDER_CHROMA_MAX_RESOLUTION /
+            DEATHADDER_CHROMA_RESOLUTION_STEP;
+
+    *res_ptr = calloc(step_number, sizeof(enum razer_mouse_res));
+    if (!*res_ptr)
+        return -ENOMEM;
+
+    for (size_t i = 0; i < step_number; ++i)
+        (*res_ptr)[i] = (i + 1) * DEATHADDER_CHROMA_RESOLUTION_STEP;
+
+    return step_number;
+}
+
+static int deathadder_chroma_supported_freqs(struct razer_mouse *m,
+                                             enum razer_mouse_freq **res_ptr)
+{
+    *res_ptr = calloc(DEATHADDER_CHROMA_SUPPORTED_FREQ_NUM,
+                      sizeof(enum razer_mouse_freq));
+    if (!*res_ptr)
+        return -ENOMEM;
+
+    enum razer_mouse_freq freqs[] = {
+        RAZER_MOUSE_FREQ_125HZ,
+        RAZER_MOUSE_FREQ_500HZ,
+        RAZER_MOUSE_FREQ_1000HZ
+    };
+
+    static_assert(ARRAY_SIZE(freqs) == DEATHADDER_CHROMA_SUPPORTED_FREQ_NUM,
+                  "The size of supported frequencies array must equal the "
+                  "declared number of supported frequencies.");
+
+    memcpy(*res_ptr, freqs, sizeof(freqs));
+    return DEATHADDER_CHROMA_SUPPORTED_FREQ_NUM;
+}
+
+static enum razer_mouse_freq deathadder_chroma_get_freq(
+        struct razer_mouse_profile *p)
+{
+    struct deathadder_chroma_driver_data *drv_data = p->mouse->drv_data;
+    return drv_data->current_freq;
+}
+
+static struct razer_mouse_dpimapping *deathadder_chroma_get_dpimapping(
+        struct razer_mouse_profile *p, struct razer_axis *axis)
+{
+    struct deathadder_chroma_driver_data *drv_data = p->mouse->drv_data;
+    return drv_data->current_dpimapping;
+}
+
+static int deathadder_chroma_change_dpimapping(struct razer_mouse_dpimapping *d,
+                                               enum razer_dimension dim,
+                                               enum razer_mouse_res res)
+{
+    if (!(d->dimension_mask | (1 << dim)))
+        return -EINVAL;
+
+    if (res == RAZER_MOUSE_RES_UNKNOWN)
+        res = RAZER_MOUSE_RES_1800DPI;
+
+    if (res < RAZER_MOUSE_RES_100DPI || res > RAZER_MOUSE_RES_10000DPI)
+        return -EINVAL;
+
+    d->res[dim] = res;
+
+    struct deathadder_chroma_driver_data *drv_data = d->mouse->drv_data;
+    if (d == drv_data->current_dpimapping)
+        return deathadder_chroma_send_set_resolution_command(d->mouse);
+
+    return 0;
+}
+
+static int deathadder_chroma_led_toggle_state(struct razer_led *led,
+                                              enum razer_led_state new_state)
+{
+    struct deathadder_chroma_driver_data *drv_data = led->u.mouse->drv_data;
+    struct deathadder_chroma_led *priv_led =
+            deathadder_chroma_get_led(drv_data, led->id);
+
+    if (!priv_led)
+        return -EINVAL;
+
+    switch (new_state) {
+        case RAZER_LED_UNKNOWN:
+        case RAZER_LED_ON:
+            priv_led->state = DEATHADDER_CHROMA_LED_STATE_ON;
+            break;
+        case RAZER_LED_OFF:
+            priv_led->state = DEATHADDER_CHROMA_LED_STATE_OFF;
+            break;
+    }
+
+    return deathadder_chroma_send_set_led_state_command(led->u.mouse, priv_led);
+}
+
+static int deathadder_chroma_led_change_color(
+        struct razer_led *led, const struct razer_rgb_color *new_color)
+{
+    // TODO EINVAL if spectrum?
+    struct deathadder_chroma_driver_data *drv_data = led->u.mouse->drv_data;
+    struct deathadder_chroma_led *priv_led =
+            deathadder_chroma_get_led(drv_data, led->id);
+
+    if (!priv_led)
+        return -EINVAL;
+
+    priv_led->color = (struct deathadder_chroma_rgb_color) {
+        .r = new_color->r,
+        .g = new_color->g,
+        .b = new_color->b
+    };
+
+    return deathadder_chroma_send_set_led_color_command(led->u.mouse, priv_led);
+}
+
+
+static int deathadder_chroma_set_freq(struct razer_mouse_profile *p,
+                                      enum razer_mouse_freq freq)
+{
+    if (freq == RAZER_MOUSE_FREQ_UNKNOWN)
+        freq = RAZER_MOUSE_FREQ_500HZ;
+
+    if (freq != RAZER_MOUSE_FREQ_125HZ && freq != RAZER_MOUSE_FREQ_500HZ &&
+        freq != RAZER_MOUSE_FREQ_1000HZ)
+        return -EINVAL;
+
+    struct deathadder_chroma_driver_data *drv_data = p->mouse->drv_data;
+    drv_data->current_freq = freq;
+
+    return deathadder_chroma_send_set_frequency_command(p->mouse);
+}
+
+static int deathadder_chroma_set_dpimapping(struct razer_mouse_profile *p,
+                                            struct razer_axis *axis,
+                                            struct razer_mouse_dpimapping *d)
+{
+    if (axis && axis->id > 0)
+        return -EINVAL;
+
+    struct deathadder_chroma_driver_data *drv_data = p->mouse->drv_data;
+    drv_data->current_dpimapping = &drv_data->dpimappings[d->nr];
+
+    return deathadder_chroma_send_set_resolution_command(p->mouse);
+}
+
+static int deathadder_chroma_translate_led_mode(
+        enum deathadder_chroma_led_mode mode)
+{
+    switch (mode) {
+        case DEATHADDER_CHROMA_LED_MODE_STATIC:
+            return RAZER_LED_MODE_STATIC;
+        case DEATHADDER_CHROMA_LED_MODE_BREATHING:
+            return RAZER_LED_MODE_BREATHING;
+        case DEATHADDER_CHROMA_LED_MODE_SPECTRUM:
+            return RAZER_LED_MODE_SPECTRUM;
+        default:
+            return -EINVAL;
+    }
+}
+
+static int deathadder_chroma_translate_razer_led_mode(enum razer_led_mode mode)
+{
+    switch (mode) {
+        case RAZER_LED_MODE_STATIC:
+            return DEATHADDER_CHROMA_LED_MODE_STATIC;
+        case RAZER_LED_MODE_BREATHING:
+            return DEATHADDER_CHROMA_LED_MODE_BREATHING;
+        case RAZER_LED_MODE_SPECTRUM:
+            return DEATHADDER_CHROMA_LED_MODE_SPECTRUM;
+        default:
+            return -EINVAL;
+    }
+}
+
+static int deathadder_chroma_led_set_mode(struct razer_led *led,
+                                          enum razer_led_mode new_mode)
+{
+    struct deathadder_chroma_driver_data *drv_data = led->u.mouse->drv_data;
+    struct deathadder_chroma_led *priv_led =
+            deathadder_chroma_get_led(drv_data, led->id);
+
+    if (!priv_led)
+        return -EINVAL;
+
+    int err = deathadder_chroma_translate_razer_led_mode(new_mode);
+    if (err < 0)
+        return err;
+
+    priv_led->mode = err;
+    return deathadder_chroma_send_set_led_mode_command(led->u.mouse, priv_led);
+}
+
+static int deathadder_chroma_get_leds(struct razer_mouse *m,
+                                      struct razer_led **leds_list)
+{
+    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
+
+    struct razer_led *scroll = zalloc(sizeof(struct razer_led));
+    if (!scroll)
+        return -ENOMEM;
+
+    struct razer_led *logo = zalloc(sizeof(struct razer_led));
+    if (!logo) {
+        free(scroll);
+        return -ENOMEM;
+    }
+
+    unsigned int supported_modes = (1 << RAZER_LED_MODE_BREATHING) |
+            (1 << RAZER_LED_MODE_SPECTRUM) | (1 << RAZER_LED_MODE_STATIC);
+
+    enum razer_led_state scroll_state =
+            drv_data->scroll_led.state == DEATHADDER_CHROMA_LED_STATE_OFF
+            ? RAZER_LED_OFF : RAZER_LED_ON;
+
+    *scroll = (struct razer_led) {
+        .id           = drv_data->scroll_led.id,
+        .name         = DEATHADDER_CHROMA_SCROLL_NAME,
+        .mode         = deathadder_chroma_translate_led_mode(drv_data->scroll_led.mode),
+        .state        = scroll_state,
+        .u.mouse      = m,
+        .toggle_state = deathadder_chroma_led_toggle_state,
+        .change_color = deathadder_chroma_led_change_color,
+        .set_mode     = deathadder_chroma_led_set_mode,
+        .next         = logo,
+        .color        = {
+            .r = drv_data->scroll_led.color.r,
+            .g = drv_data->scroll_led.color.g,
+            .b = drv_data->scroll_led.color.b,
+            .valid = 1
+        },
+        .supported_modes_mask = supported_modes
+    };
+
+    enum razer_led_state logo_state =
+            drv_data->logo_led.state == DEATHADDER_CHROMA_LED_STATE_OFF
+            ? RAZER_LED_OFF : RAZER_LED_ON;
+
+    *logo = (struct razer_led) {
+        .id           = drv_data->logo_led.id,
+        .name         = DEATHADDER_CHROMA_LOGO_NAME,
+        .mode         = deathadder_chroma_translate_led_mode(drv_data->logo_led.mode),
+        .state        = logo_state,
+        .u.mouse      = m,
+        .toggle_state = deathadder_chroma_led_toggle_state,
+        .change_color = deathadder_chroma_led_change_color,
+        .set_mode     = deathadder_chroma_led_set_mode,
+        .color        = {
+            .r = drv_data->logo_led.color.r,
+            .g = drv_data->logo_led.color.g,
+            .b = drv_data->logo_led.color.b,
+            .valid = 1
+        },
+        .supported_modes_mask = supported_modes
+    };
+
+    *leds_list = scroll;
+    return DEATHADDER_CHROMA_LED_NUM;
+}
+
+int razer_deathadder_chroma_init(struct razer_mouse *m,
+                                 struct libusb_device *usbdev)
+{
+    struct deathadder_chroma_driver_data *drv_data = zalloc(sizeof(*drv_data));
+    if (!drv_data)
+        return -ENOMEM;
+
+    razer_event_spacing_init(&drv_data->packet_spacing,
+                             DEATHADDER_CHROMA_PACKET_SPACING_MS);
+
+    enum razer_mouse_res resolution_stages[] = {
+        RAZER_MOUSE_RES_800DPI,
+        RAZER_MOUSE_RES_1800DPI,
+        RAZER_MOUSE_RES_3500DPI,
+        RAZER_MOUSE_RES_5600DPI,
+        RAZER_MOUSE_RES_10000DPI
+    };
+
+    static_assert(ARRAY_SIZE(resolution_stages) ==
+                  DEATHADDER_CHROMA_DPIMAPPINGS_NUM,
+                  "The number of resolution stages must equal the declared "
+                  "number of dpi mappings.");
+
+    for (int i = 0; i < DEATHADDER_CHROMA_DPIMAPPINGS_NUM; ++i) {
+        drv_data->dpimappings[i] = (struct razer_mouse_dpimapping) {
+            .nr             = i,
+            .change         = deathadder_chroma_change_dpimapping,
+            .dimension_mask = (1 << RAZER_DIM_X) | (1 << RAZER_DIM_Y),
+            .mouse          = m
+        };
+
+        drv_data->dpimappings[i].res[RAZER_DIM_X] =
+                drv_data->dpimappings[i].res[RAZER_DIM_Y] =
+                    resolution_stages[i];
+    }
+
+    drv_data->current_dpimapping = &drv_data->dpimappings[1];
+    drv_data->current_freq = RAZER_MOUSE_FREQ_500HZ;
+
+    drv_data->scroll_led = (struct deathadder_chroma_led) {
+        .id    = DEATHADDER_CHROMA_LED_ID_SCROLL,
+        .mode  = DEATHADDER_CHROMA_LED_MODE_SPECTRUM,
+        .state = DEATHADDER_CHROMA_LED_STATE_ON,
+        .color = { 0x00, 0xFF, 0x00 }
+    };
+
+    drv_data->logo_led = (struct deathadder_chroma_led) {
+        .id    = DEATHADDER_CHROMA_LED_ID_LOGO,
+        .mode  = DEATHADDER_CHROMA_LED_MODE_SPECTRUM,
+        .state = DEATHADDER_CHROMA_LED_STATE_ON,
+        .color = { 0x00, 0xFF, 0x00 }
+    };
+
+    razer_init_axes(drv_data->axes,
+                    "X/Y", RAZER_AXIS_INDEPENDENT_DPIMAPPING,
+                    "Scroll", 0,
+                    NULL, 0);
+
+    m->drv_data = drv_data;
+
+    int err;
+    if ((err = razer_usb_add_used_interface(m->usb_ctx, 0, 0)) ||
+        (err = m->claim(m)))
+    {
+        free(drv_data);
+        return err;
+    }
+
+    struct deathadder_chroma_led *scroll_led = &drv_data->scroll_led;
+    struct deathadder_chroma_led *logo_led   = &drv_data->logo_led;
+
+    if ((err = deathadder_chroma_send_init_command          (m)) ||
+        (err = deathadder_chroma_send_set_resolution_command(m)) ||
+        (err = deathadder_chroma_send_get_firmware_command  (m)) ||
+        (err = deathadder_chroma_send_get_serial_no_command (m)) ||
+        (err = deathadder_chroma_send_set_frequency_command (m)) ||
+        (err = deathadder_chroma_send_set_led_state_command (m, scroll_led)) ||
+        (err = deathadder_chroma_send_set_led_mode_command  (m, scroll_led)) ||
+        (err = deathadder_chroma_send_set_led_color_command (m, scroll_led)) ||
+        (err = deathadder_chroma_send_set_led_state_command (m, logo_led)) ||
+        (err = deathadder_chroma_send_set_led_mode_command  (m, logo_led)) ||
+        (err = deathadder_chroma_send_set_led_color_command (m, logo_led)))
+    {
+        m->release(m);
+        free(drv_data);
+        return err;
+    }
+
+    m->release(m);
+
+    drv_data->profile = (struct razer_mouse_profile) {
+        .mouse          = m,
+        .get_freq       = deathadder_chroma_get_freq,
+        .set_freq       = deathadder_chroma_set_freq,
+        .get_dpimapping = deathadder_chroma_get_dpimapping,
+        .set_dpimapping = deathadder_chroma_set_dpimapping
+    };
+
+    razer_generic_usb_gen_idstr(usbdev, m->usb_ctx->h,
+                                DEATHADDER_CHROMA_DEVICE_NAME, false,
+                                drv_data->serial, m->idstr);
+
+    m->type                  = RAZER_MOUSETYPE_DEATHADDER;
+    m->get_fw_version        = deathadder_chroma_get_fw_version;
+    m->global_get_leds       = deathadder_chroma_get_leds;
+    m->get_profiles          = deathadder_chroma_get_profiles;
+    m->supported_axes        = deathadder_chroma_supported_axes;
+    m->supported_resolutions = deathadder_chroma_supported_resolutions;
+    m->supported_freqs       = deathadder_chroma_supported_freqs;
+    m->supported_dpimappings = deathadder_chroma_supported_dpimappings;
+
+    return 0;
+}
+
+void razer_deathadder_chroma_release(struct razer_mouse *m)
+{
+    struct deathadder_chroma_driver_data *drv_data = m->drv_data;
+    free(drv_data);
+    m->drv_data = NULL;
+}

--- a/librazer/hw_deathadder_chroma.h
+++ b/librazer/hw_deathadder_chroma.h
@@ -1,0 +1,11 @@
+#ifndef RAZER_HW_DEATHADDER_CHROMA_H_
+#define RAZER_HW_DEATHADDER_CHROMA_H_
+
+#include "razer_private.h"
+
+int razer_deathadder_chroma_init(struct razer_mouse *m,
+                                 struct libusb_device *usbdev);
+
+void razer_deathadder_chroma_release(struct razer_mouse *m);
+
+#endif /* RAZER_HW_DEATHADDER_CHROMA_H_ */

--- a/librazer/hw_deathadder_chroma.h
+++ b/librazer/hw_deathadder_chroma.h
@@ -4,7 +4,7 @@
 #include "razer_private.h"
 
 int razer_deathadder_chroma_init(struct razer_mouse *m,
-                                 struct libusb_device *usbdev);
+				 struct libusb_device *usbdev);
 
 void razer_deathadder_chroma_release(struct razer_mouse *m);
 

--- a/librazer/librazer.c
+++ b/librazer/librazer.c
@@ -21,6 +21,7 @@
 
 #include "hw_deathadder.h"
 #include "hw_deathadder2013.h"
+#include "hw_deathadder_chroma.h"
 #include "hw_naga.h"
 #include "hw_krait.h"
 #include "hw_lachesis.h"
@@ -76,6 +77,12 @@ static const struct razer_mouse_base_ops razer_deathadder2013_base_ops = {
 	.type			= RAZER_MOUSETYPE_DEATHADDER,
 	.init			= razer_deathadder2013_init,
 	.release		= razer_deathadder2013_release,
+};
+
+static const struct razer_mouse_base_ops razer_deathadder_chroma_base_ops = {
+	.type			= RAZER_MOUSETYPE_DEATHADDER,
+	.init			= razer_deathadder_chroma_init,
+	.release		= razer_deathadder_chroma_release,
 };
 
 static const struct razer_mouse_base_ops razer_naga_base_ops = {
@@ -140,6 +147,7 @@ static const struct razer_usb_device razer_usbdev_table[] = {
 	USB_MOUSE(0x1532, 0x0016, &razer_deathadder_base_ops), /* 3500 DPI */
 	USB_MOUSE(0x1532, 0x0029, &razer_deathadder_base_ops), /* black edition */
 	USB_MOUSE(0x1532, 0x0037, &razer_deathadder2013_base_ops), /* 2013 edition */
+	USB_MOUSE(0x1532, 0x0043, &razer_deathadder_chroma_base_ops), /* Chroma edition */
 //	USB_MOUSE(0x04B4, 0xE006, &razer_deathadder_base_ops), /* cypress bootloader */
 	USB_MOUSE(0x1532, 0x0003, &razer_krait_base_ops),
 	USB_MOUSE(0x1532, 0x000C, &razer_lachesis_base_ops), /* classic */

--- a/scripts/cmake.global
+++ b/scripts/cmake.global
@@ -14,7 +14,7 @@ add_definitions("-D_BSD_SOURCE")
 add_definitions("-DRAZERCFG_BUILD")
 add_definitions("-D_FORTIFY_SOURCE=2")
 
-set(GENERIC_COMPILE_FLAGS "-O2 -std=gnu99 -Wall -Wformat -Wformat-security -fstack-protector")
+set(GENERIC_COMPILE_FLAGS "-O2 -std=c11 -Wall -Wformat -Wformat-security -fstack-protector")
 
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG")
 

--- a/ui/pyrazer/main.py
+++ b/ui/pyrazer/main.py
@@ -145,9 +145,9 @@ class RazerLEDMode(object):
 
 	def toString(self):
 		return {
-			self.LED_MODE_STATIC:    'Static',
-			self.LED_MODE_SPECTRUM:  'Spectrum',
-			self.LED_MODE_BREATHING: 'Breathing'
+			self.LED_MODE_STATIC:    'static',
+			self.LED_MODE_SPECTRUM:  'spectrum',
+			self.LED_MODE_BREATHING: 'breathing'
 		}[self.val]
 
 	@classmethod
@@ -158,6 +158,14 @@ class RazerLEDMode(object):
 				modes.append(cls(mode))
 
 		return modes
+
+	@classmethod
+	def fromString(cls, string):
+		return {
+			'static':    cls(cls.LED_MODE_STATIC),
+			'spectrum':  cls(cls.LED_MODE_SPECTRUM),
+			'breathing': cls(cls.LED_MODE_BREATHING)
+		}[string]
 
 
 class RazerLED(object):

--- a/ui/pyrazer/main.py
+++ b/ui/pyrazer/main.py
@@ -153,8 +153,8 @@ class RazerLEDMode(object):
 	@classmethod
 	def listFromSupportedModes(cls, mask):
 		modes = []
-		for mode in [cls.LED_MODE_STATIC, cls.LED_MODE_SPECTRUM, cls.LED_MODE_BREATHING]:
-			if mask | (1 << mode):
+		for mode in (cls.LED_MODE_STATIC, cls.LED_MODE_SPECTRUM, cls.LED_MODE_BREATHING):
+			if mask & (1 << mode):
 				modes.append(cls(mode))
 
 		return modes

--- a/ui/qrazercfg
+++ b/ui/qrazercfg
@@ -150,9 +150,23 @@ class OneLedConfig(QWidget):
 		self.layout().addWidget(self.stateCb, 0, 0)
 		self.stateCb.setCheckState(Qt.Checked if led.state else Qt.Unchecked)
 
+		if led.supported_modes:
+			self.modeComBox = WrappedComboBox(self)
+			self.layout().addWidget(self.modeComBox, 0, 1)
+			for mode in led.supported_modes:
+				self.modeComBox.addItem(mode.toString(), mode.val)
+
+			self.connect(self.modeComBox, SIGNAL("currentIndexChanged(int)"),
+					self.modeChanged)
+
+			index = self.modeComBox.findData(led.mode.val)
+			if index >= 0:
+				self.modeComBox.setCurrentIndex(index)
+
+
 		if led.color is not None and led.canChangeColor:
 			self.colorPb = QPushButton(self.tr("change color..."), self)
-			self.layout().addWidget(self.colorPb, 0, 1)
+			self.layout().addWidget(self.colorPb, 0, 2)
 
 			self.connect(self.colorPb, SIGNAL("released()"),
 				     self.colorChangePressed)
@@ -172,6 +186,10 @@ class OneLedConfig(QWidget):
 		self.led.color.r = c.red()
 		self.led.color.g = c.green()
 		self.led.color.b = c.blue()
+		razer.setLed(self.ledsWidget.mouseWidget.mouse, self.led)
+
+	def modeChanged(self, currentIndex):
+		self.led.mode.val = self.modeComBox.itemData(currentIndex)
 		razer.setLed(self.ledsWidget.mouseWidget.mouse, self.led)
 
 class LedsWidget(QGroupBox):

--- a/ui/razercfg
+++ b/ui/razercfg
@@ -149,11 +149,12 @@ class OpPrintLeds(Operation):
 		output = []
 		for led in leds:
 			state = "on" if led.state else "off"
+			mode  = led.mode.toString()
 			color = ""
 			if led.color is not None:
-				color = "/color#%02X%02X%02X" %\
+				color = "color#%02X%02X%02X" %\
 					(led.color.r, led.color.g, led.color.b)
-			output.append("%s => %s%s" % (led.name, state, color))
+			output.append("%s => %s/%s/%s" % (led.name, state, mode, color))
 		print(",  ".join(output))
 
 class OpSetProfile(Operation):
@@ -222,6 +223,30 @@ class OpSetLedColor(Operation):
 					      Razer.strerror(error))
 		except (IndexError, ValueError):
 			raise RazerEx("Invalid parameter to --setledcolor option")
+
+class OpSetLedMode(Operation):
+	def __init__(self, param):
+		self.param = param
+
+	def run(self, idstr):
+		try:
+			(profile, config) = self.parseProfileValueStr(self.param, idstr, 2)
+			ledName = config[0].strip().lower()
+			newMode = RazerLEDMode.fromString(config[1].lower())
+			if profile is None:
+				profile = Razer.PROFILE_INVALID
+			else:
+				profile -= 1
+			leds = getRazer().getLeds(idstr, profile)
+			led = [led for led in leds if led.name.lower() == ledName.lower()][0]
+			led.mode = newMode
+			error = getRazer().setLed(idstr, led)
+			if error:
+				raise RazerEx("Failed to set LED mode (%s)" %\
+					      Razer.strerror(error))
+		except (KeyError, IndexError, ValueError):
+			raise RazerEx("Invalid parameter to --setledmode option")
+
 
 class OpSetRes(Operation):
 	def __init__(self, param):
@@ -367,6 +392,9 @@ def usage():
 	print("                                    Use the special identifier \"all\"")
 	print("                                    to toggle all supported LEDs.")
 	print("-c|--setledcolor [PROF:]LED:rrggbb  Set LED color to RGB 'rrggbb'")
+	print("-m|--setledmode  [PROF:]LED:MODE    Set LED mode to MODE ('static', 'spectrum'")
+	print("                                                               or 'breathing')")
+	print("")
 	print("-X|--flashfw FILE                   Flash a firmware image to the device")
 	print("")
 	print("The profile number \"PROF\" may be 0 for the current profile. If omitted,")
@@ -388,12 +416,12 @@ def parse_args():
 
 	try:
 		(opts, args) = getopt.getopt(sys.argv[1:],
-			"hvBsKd:r:Rf:FLl:VS:X:c:p:P",
+			"hvBsKd:r:Rf:FLl:VS:X:c:p:Pm:",
 			[ "help", "version", "background",
 			  "scan", "reconfigure", "device=", "res=",
 			  "getres", "freq=", "getfreq", "leds", "setled=",
 			  "fwver", "config=", "sleep=", "flashfw=",
-			  "setledcolor=",
+			  "setledcolor=", "setledmode=",
 			  "profile=", "getprofile", ])
 	except getopt.GetoptError:
 		usage()
@@ -476,6 +504,11 @@ def parse_args():
 			if not currentDevOps:
 				currentDevOps = DevOps(findDevice())
 			currentDevOps.add(OpSetLedColor(v))
+			continue
+		if o in ("-m", "--setledmode"):
+			if not currentDevOps:
+				currentDevOps = DevOps(findDevice())
+			currentDevOps.add(OpSetLedMode(v))
 			continue
 		if o in ("-V", "--fwver"):
 			if not currentDevOps:


### PR DESCRIPTION
I reverse-engineered DeathAdder Chroma protocol and implemented a driver module for it. Other than that, the biggest changes are

* the addition of "LED mode" parameter (allowing to switch LEDs between static, spectrum and breathing modes) that triggered changes in the library and client-side code
* the change from `-std=gnu99` to `-std=c11`. The only two features I use in the code are anonymous structs/unions and `static_assert`, but I don't think the change is a big deal.

The changes are also described in some detail in commit messages.