### PR TITLE
Debian packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,16 @@ Build-Depends: debhelper (>= 9),
 
 Package: razercfg
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${python3:Depends}, ${shlibs:Depends}, ${misc:Depends}
 Suggests: python3-pyside
 Description: Razer device configuration tool
- This is a configuration utility for Razer devices on Linux systems.
+ This is a system daemon and Python-powered CLI configuration utility for Razer
+ devices on Linux systems.
+
+Package: qrazercfg
+Architecture: any
+Depends: ${misc:Depends}, python3-pyside, razercfg
+Description: Graphical Razer device configuration tool
+ Python- and QT-powered configuration utility for the configuration of Razer
+ devices on Linux systems.
+

--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,7 @@ Build-Depends: debhelper (>= 9),
  libusb-1.0-0-dev,
  pkg-config,
  python3-dev,
+ dh-python
 
 Package: razercfg
 Architecture: any

--- a/debian/install
+++ b/debian/install
@@ -1,1 +1,0 @@
-razer.conf /etc

--- a/debian/qrazercfg.install
+++ b/debian/qrazercfg.install
@@ -1,0 +1,2 @@
+usr/bin/qrazercfg usr/bin
+usr/share/applications/razercfg.desktop /usr/share/applications

--- a/debian/razercfg.install
+++ b/debian/razercfg.install
@@ -1,0 +1,9 @@
+razer.conf /etc
+etc/pm/sleep.d/50-razer /etc/pm/sleep.d
+lib/systemd/system/razerd.service lib/systemd/system
+lib/udev/rules.d/80-razer.rules lib/udev/rules.d
+usr/lib/python3.4/site-packages/* usr/lib/python3/dist-packages
+usr/bin/razerd /usr/bin
+usr/bin/razercfg /usr/bin
+usr/bin/razer-gamewrapper /usr/bin
+usr/lib/librazer.so /usr/lib

--- a/debian/razercfg.install
+++ b/debian/razercfg.install
@@ -7,3 +7,4 @@ usr/bin/razerd /usr/bin
 usr/bin/razercfg /usr/bin
 usr/bin/razer-gamewrapper /usr/bin
 usr/lib/librazer.so /usr/lib
+usr/lib/librazer.so.1 /usr/lib

--- a/debian/rules
+++ b/debian/rules
@@ -1,12 +1,7 @@
 #!/usr/bin/make -f
 
-override_dh_install:
-	dh_install
-	find ./debian/ -type d -name site-packages -prune -execdir mv site-packages dist-packages \;
-	find ./debian/ -type d -name __pycache__ -prune -execdir rm -r __pycache__ \;
-
 override_dh_installinit:
 	dh_installinit --name=razerd
 
 %:
-	dh $@ --with systemd
+	dh $@ --with systemd --with python3

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,8 @@
 #!/usr/bin/make -f
 
+override_dh_install:
+	dh_install --fail-missing
+
 override_dh_installinit:
 	dh_installinit --name=razerd
 

--- a/librazer/CMakeLists.txt
+++ b/librazer/CMakeLists.txt
@@ -21,6 +21,8 @@ add_library(razer SHARED
 	    hw_taipan.c)
 
 set_target_properties(razer PROPERTIES COMPILE_FLAGS ${GENERIC_COMPILE_FLAGS})
+set_target_properties(razer PROPERTIES SOVERSION 1)
+
 
 add_definitions("-Du_int8_t=uint8_t -Du_int16_t=uint16_t -Du_int32_t=uint32_t")
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -48,7 +48,7 @@ uninstall_prefix()
 		 /bin/razercfg /bin/qrazercfg /bin/razer-gamewrapper\
 		 /sbin/razerd /bin/razerd\
 		 /share/applications/razercfg.desktop\
-		 /lib/librazer.so; do
+		 /lib/librazer.so /lib/librazer.so.1; do
 
 		local path="${prefix}${f}"
 		[ -e "$path" -o -h "$path" ] || continue


### PR DESCRIPTION
After #56 is accepted, this would be nice. It cleans up the Debian packaging quite a lot!

It also splits the binaries into razercfg and qrazercfg, so that the qrazercfg can actually depend on python3-pyside.
