### PR TITLE
Fix the Lachesis button mappings.

### DIFF
--- a/librazer/hw_lachesis.c
+++ b/librazer/hw_lachesis.c
@@ -50,10 +50,10 @@ enum lachesis_phys_button {
 	LACHESIS_PHYSBUT_LEFT = 0x01,	/* Left button */
 	LACHESIS_PHYSBUT_RIGHT,		/* Right button */
 	LACHESIS_PHYSBUT_MIDDLE,	/* Middle button */
-	LACHESIS_PHYSBUT_LFRONT,	/* Left side, front button */
-	LACHESIS_PHYSBUT_LREAR,		/* Left side, rear button */
 	LACHESIS_PHYSBUT_RFRONT,	/* Right side, front button */
 	LACHESIS_PHYSBUT_RREAR,		/* Right side, rear button */
+	LACHESIS_PHYSBUT_LFRONT,	/* Left side, front button */
+	LACHESIS_PHYSBUT_LREAR,		/* Left side, rear button */
 	LACHESIS_PHYSBUT_TFRONT,	/* Top side, front button */
 	LACHESIS_PHYSBUT_TREAR,		/* Top side, rear button */
 	LACHESIS_PHYSBUT_SCROLLUP,	/* Scroll wheel up */


### PR DESCRIPTION
Both the physical and logic button mappings seem to be wrong, at least for my Lachesis Classic.

These two commits fix both issues.

Without it, my side buttons end up getting mapped to profile changes instead of mouse buttons, which is less useful than it could be.