### PR TITLE
Close client fd on disconnect

### DIFF
--- a/razerd/razerd.c
+++ b/razerd/razerd.c
@@ -702,6 +702,7 @@ static void disconnect_client(struct client **client_list, struct client *client
 		logdebug("Privileged client disconnected (fd=%d)\n", client->fd);
 	else
 		logdebug("Client disconnected (fd=%d)\n", client->fd);
+	close(client->fd);
 	free_client(client);
 }
 


### PR DESCRIPTION
I noticed that after razerd had been running for a while it would use a lot of cpu. I discovered that this is due to a combination of three bugs:

1. Every time a usb device is disconnected, razerd thinks that five clients and five privileged clients connected and disconnected
2. razerd doesn't close client socket file descriptors when they disconnect
3. When razerd can't open any more file descriptors, the main loop runs continuously at full speed, maxing out a cpu thread

This pull request effectively solves the issue by fixing the second bug, but it would probably be a good idea to look at the other bugs as well.